### PR TITLE
fix(persist-form): doesn't set state properly for multiple forms

### DIFF
--- a/akita/src/plugins/persist-form/persist-ng-form-plugin.ts
+++ b/akita/src/plugins/persist-form/persist-ng-form-plugin.ts
@@ -48,7 +48,7 @@ export class PersistNgFormPlugin<T = any> extends AkitaPlugin {
   }
 
   private activate() {
-    if (!(this.getQuery().getSnapshot() as AkitaFormProp<T>).akitaForm) {
+    if (!(this.getQuery().getSnapshot() as AkitaFormProp<T>)[this.params.formKey]) {
       this.getStore().setState(state => {
         return {
           ...state,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When using persist-form plugin with 2 or more forms, and the first PersistNgFormPlugin instance uses the default formKey property value, all subsequent PersistNgFormPlugin instances won't change store state properly. PS: I don't know if this was the intentional behaviour.


## What is the new behavior?
All forms be correctly  enhanced by PersistNgFormPlugin 

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
