### PR TITLE
fix(entity-dirty-check-plugin): change signature of isDirty

### DIFF
--- a/akita/__tests__/dirty-check.spec.ts
+++ b/akita/__tests__/dirty-check.spec.ts
@@ -1,5 +1,6 @@
 import { DirtyCheckPlugin, EntityDirtyCheckPlugin } from '../src/index';
 import { Widget, WidgetsQuery, WidgetsStore } from './setup';
+import { Observable } from 'rxjs';
 
 describe('DirtyCheck', () => {
   function createWidget() {
@@ -198,5 +199,39 @@ describe('DirtyCheckEntity', () => {
     expect(spy).toHaveBeenLastCalledWith(true);
     widgetsStore.update(5, { title: 'Widget 5' });
     expect(spy).toHaveBeenLastCalledWith(false);
+  });
+
+  it('should return isDirty as observable by default', () => {
+    const widget = createWidget();
+    widgetsStore.add(widget);
+    const isDirty = collection.isDirty(widget.id);
+    expect(isDirty).toBeInstanceOf(Observable);
+  });
+
+  it('should return isDirty as observable', () => {
+    const widget = createWidget();
+    widgetsStore.add(widget);
+    const isDirty = collection.isDirty(widget.id, true);
+    expect(isDirty).toBeInstanceOf(Observable);
+  });
+
+  it('should return isDirty as boolean', () => {
+    const widget = createWidget();
+    widgetsStore.add(widget);
+    const isDirty = collection.isDirty(widget.id, false);
+    expect(typeof isDirty).toEqual('boolean');
+  });
+
+  it('should return false for hasHead()', () => {
+    const widget = createWidget();
+    widgetsStore.add(widget);
+    expect(collection.hasHead(widget.id)).toBeFalsy();
+  });
+
+  it('should return true for hasHead()', () => {
+    const widget = createWidget();
+    widgetsStore.add(widget);
+    collection.setHead(widget.id);
+    expect(collection.hasHead(widget.id)).toBeTruthy();
   });
 });

--- a/akita/src/plugins/dirty-check/entity-dirty-check-plugin.ts
+++ b/akita/src/plugins/dirty-check/entity-dirty-check-plugin.ts
@@ -25,14 +25,29 @@ export class EntityDirtyCheckPlugin<E, P extends DirtyCheckPlugin<E, any> = Dirt
     return this;
   }
 
+  hasHead(id: ID) {
+    if (this.entities.has(id)) {
+      const entity = this.getEntity(id);
+      return entity.hasHead();
+    }
+
+    return false;
+  }
+
   reset(ids?: IDS, params: DirtyCheckResetParams = {}) {
     this.forEachId(ids, e => e.reset(params));
   }
 
-  isDirty(id: ID) {
+  isDirty(id: ID): Observable<boolean>;
+  isDirty(id: ID, asObservable: true): Observable<boolean>;
+  isDirty(id: ID, asObservable: false): boolean;
+  isDirty(id: ID, asObservable = true): Observable<boolean> | boolean {
     if (this.entities.has(id)) {
-      return this.getEntity(id).isDirty$;
+      const entity = this.getEntity(id);
+      return asObservable ? entity.isDirty$ : entity.isDirty();
     }
+
+    return false;
   }
 
   isSomeDirty(): Observable<boolean> {


### PR DESCRIPTION
Add signature for is dirty to be able to return boolean.
Add public API for hasHead() 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
