### PR TITLE
feat: EntityStore.update/remove should accept predicate for ids

### DIFF
--- a/akita/__tests__/crud.spec.ts
+++ b/akita/__tests__/crud.spec.ts
@@ -1,7 +1,7 @@
-import { CRUD } from '../src/internal/crud';
-import { coerceArray } from '../src/internal/utils';
-import { AkitaEntityNotExistsError, AkitaInvalidEntityState } from '../src/internal/error';
 import { ID } from '../src/api/types';
+import { CRUD } from '../src/internal/crud';
+import { AkitaEntityNotExistsError, AkitaInvalidEntityState } from '../src/internal/error';
+import { coerceArray } from '../src/internal/utils';
 
 class Todo {
   id: ID;
@@ -73,6 +73,29 @@ describe('CRUD', () => {
       expect(oldOne).not.toBe(store.entities[1]);
       expect(oldTwo).not.toBe(store.entities[2]);
       expect(oldThree).not.toBe(store.entities[3]);
+
+      expect(store.entities[1] instanceof Todo).toBe(true);
+      expect(store.entities[2] instanceof Todo).toBe(true);
+      expect(store.entities[3] instanceof Todo).toBe(true);
+
+      expect(getEntitiesCount(store)).toBe(3);
+      expect(store.ids.length).toBe(3);
+    });
+
+    it('should update many with callback', () => {
+      const oldOne = store.entities[1];
+      const oldTwo = store.entities[2];
+      const oldThree = store.entities[3];
+
+      store = crud._update(store, [1, 2], e => ({ title: 'changed many with callback ' + e.id }));
+
+      expect(store.entities[1].title).toBe('changed many with callback 1');
+      expect(store.entities[2].title).toBe('changed many with callback 2');
+      expect(store.entities[3].title).toBe('changed many');
+
+      expect(oldOne).not.toBe(store.entities[1]);
+      expect(oldTwo).not.toBe(store.entities[2]);
+      expect(oldThree).toBe(store.entities[3]);
 
       expect(store.entities[1] instanceof Todo).toBe(true);
       expect(store.entities[2] instanceof Todo).toBe(true);

--- a/akita/__tests__/entity-store.spec.ts
+++ b/akita/__tests__/entity-store.spec.ts
@@ -106,6 +106,14 @@ describe('EntitiesStore', () => {
       expect(store.entities[2].title).toEqual('update');
     });
 
+    it('should not update by predicate which does not match any entity', () => {
+      store.add(new Todo({ id: 1 }));
+      store.add(new Todo({ id: 2 }));
+      store.update(e => e.title === '3', { title: 'update' });
+      expect(store.entities[1].title).toEqual('1');
+      expect(store.entities[2].title).toEqual('2');
+    });
+
     it('should throw if the entity does not exists', () => {
       store.add(new Todo({ id: 1 }));
       expect(function() {
@@ -210,7 +218,7 @@ describe('EntitiesStore', () => {
       expect(store._value().ids.length).toEqual(0);
     });
 
-    it('should remove many with callback', () => {
+    it('should remove many by predicate', () => {
       const todo = new Todo({ id: 1 });
       const todo2 = new Todo({ id: 2 });
       store.add(todo);
@@ -219,6 +227,17 @@ describe('EntitiesStore', () => {
       expect(store.entities[1]).toBeUndefined();
       expect(store.entities[2]).toBe(todo2);
       expect(store._value().ids.length).toEqual(1);
+    });
+
+    it('should not remove any by predicate which does not match any entity', () => {
+      const todo = new Todo({ id: 1 });
+      const todo2 = new Todo({ id: 2 });
+      store.add(todo);
+      store.add(todo2);
+      store.remove(e => e.id === 3);
+      expect(store.entities[1]).toBe(todo);
+      expect(store.entities[2]).toBe(todo2);
+      expect(store._value().ids.length).toEqual(2);
     });
 
     it('should remove all', () => {

--- a/akita/__tests__/entity-store.spec.ts
+++ b/akita/__tests__/entity-store.spec.ts
@@ -1,5 +1,5 @@
-import { Todo, TodosStore, TodosStoreCustomID } from './setup';
 import { AkitaEntityNotExistsError, AkitaNoActiveError } from '../src/internal/error';
+import { Todo, TodosStore, TodosStoreCustomID } from './setup';
 
 let store = new TodosStore();
 
@@ -80,11 +80,29 @@ describe('EntitiesStore', () => {
       expect(store.entities[3].title).toEqual('3');
     });
 
+    it('should update many with callback using entity object', () => {
+      store.add(new Todo({ id: 1 }));
+      store.add(new Todo({ id: 2 }));
+      store.add(new Todo({ id: 3 }));
+      store.update([1, 2], entity => ({ title: 'update' + entity.id }));
+      expect(store.entities[1].title).toEqual('update1');
+      expect(store.entities[2].title).toEqual('update2');
+      expect(store.entities[3].title).toEqual('3');
+    });
+
     it('should update all', () => {
       store.add(new Todo({ id: 1 }));
       store.add(new Todo({ id: 2 }));
       store.update(null, { title: 'update' });
       expect(store.entities[1].title).toEqual('update');
+      expect(store.entities[2].title).toEqual('update');
+    });
+
+    it('should update by predicate', () => {
+      store.add(new Todo({ id: 1 }));
+      store.add(new Todo({ id: 2 }));
+      store.update(e => e.title === '2', { title: 'update' });
+      expect(store.entities[1].title).toEqual('1');
       expect(store.entities[2].title).toEqual('update');
     });
 
@@ -190,6 +208,17 @@ describe('EntitiesStore', () => {
       expect(store.entities[1]).toBeUndefined();
       expect(store.entities[2]).toBeUndefined();
       expect(store._value().ids.length).toEqual(0);
+    });
+
+    it('should remove many with callback', () => {
+      const todo = new Todo({ id: 1 });
+      const todo2 = new Todo({ id: 2 });
+      store.add(todo);
+      store.add(todo2);
+      store.remove(e => e.id === 1);
+      expect(store.entities[1]).toBeUndefined();
+      expect(store.entities[2]).toBe(todo2);
+      expect(store._value().ids.length).toEqual(1);
     });
 
     it('should remove all', () => {

--- a/akita/src/api/entity-store.ts
+++ b/akita/src/api/entity-store.ts
@@ -1,10 +1,10 @@
 import { _crud } from '../internal/crud';
-import { ActiveState, Entities, EntityState, HashMap, ID, Newable } from './types';
+import { AkitaImmutabilityError, assertActive } from '../internal/error';
+import { Action, globalState } from '../internal/global-state';
 import { coerceArray, entityExists, isFunction, toBoolean } from '../internal/utils';
 import { isDev, Store } from './store';
-import { AkitaImmutabilityError, assertActive } from '../internal/error';
 import { applyTransaction } from './transaction';
-import { Action, globalState } from '../internal/global-state';
+import { ActiveState, Entities, EntityState, HashMap, ID, Newable } from './types';
 
 /**
  * The Root Store that every sub store needs to inherit and
@@ -125,6 +125,9 @@ export class EntityStore<S extends EntityState<E>, E> extends Store<S> {
    *   name: 'New Name'
    * });
    *
+   * this.store.update(e => e.name === 'value', {
+   *   name: 'New Name'
+   * });
    *
    * this.store.update(null, {
    *   name: 'New Name'
@@ -132,16 +135,27 @@ export class EntityStore<S extends EntityState<E>, E> extends Store<S> {
    *
    */
   update(id: ID | ID[] | null, newStateFn: ((entity: Readonly<E>) => Partial<E>));
-  update(id: ID | ID[] | null, newStateFn: Partial<E>);
+  update(id: ID | ID[] | null, newState: Partial<E>);
   update(id: ID | ID[] | null, newState: Partial<S>);
+  update(predicate: ((entity: Readonly<E>) => boolean), newStateFn: ((entity: Readonly<E>) => Partial<E>));
+  update(predicate: ((entity: Readonly<E>) => boolean), newState: Partial<E>);
+  update(predicate: ((entity: Readonly<E>) => boolean), newState: Partial<S>);
   update(newState: Partial<S>);
-  update(stateOrId: ID | ID[] | null | Partial<S>, newStateFn?: ((entity: Readonly<E>) => Partial<E>) | Partial<E> | Partial<S>) {
-    const ids = toBoolean(stateOrId) ? coerceArray(stateOrId) : this._value().ids;
-    isDev() && globalState.setAction({ type: 'Update Entity', entityId: ids });
-
+  update(idsOrFn: ID | ID[] | null | Partial<S> | ((entity: Readonly<E>) => boolean), newStateOrFn?: ((entity: Readonly<E>) => Partial<E>) | Partial<E> | Partial<S>) {
     this.setState(state => {
-      const newState = isFunction(newStateFn) ? newStateFn(state.entities[stateOrId as ID]) : newStateFn;
-      return _crud._update(state, ids, newState);
+      let ids: ID[] = [];
+      if (isFunction(idsOrFn)) {
+        for (const id in state.entities) {
+          if (idsOrFn(state.entities[id])) {
+            ids.push(id);
+          }
+        }
+      } else {
+        ids = toBoolean(idsOrFn) ? coerceArray(idsOrFn) : this._value().ids;
+      }
+      isDev() && globalState.setAction({ type: 'Update Entity', entityId: ids });
+
+      return _crud._update(state, ids, newStateOrFn);
     });
   }
 
@@ -194,17 +208,31 @@ export class EntityStore<S extends EntityState<E>, E> extends Store<S> {
    * @example
    * this.store.remove(5);
    * this.store.remove([1,2,3]);
+   * this.store.remove(entity => entity.id === 1);
    * this.store.remove();
    */
-  remove(id?: ID | ID[]) {
+  remove(id?: ID | ID[]);
+  remove(predicate: (entity: Readonly<E>) => boolean);
+  remove(idsOrFn?: ID | ID[] | ((entity: Readonly<E>) => boolean)) {
     if (this._value().ids.length === 0) return;
-    const idExists = toBoolean(id);
-    if (!idExists) this.setPristine();
+    const idPassed = toBoolean(idsOrFn);
+    if (!idPassed) this.setPristine();
 
-    const ids = idExists ? coerceArray(id) : null;
-    isDev() && globalState.setAction({ type: 'Remove Entity', entityId: ids });
+    this.setState(state => {
+      let ids: ID[] = [];
+      if (isFunction(idsOrFn)) {
+        for (const id in state.entities) {
+          if (idsOrFn(state.entities[id])) {
+            ids.push(state.entities[id][this.config.idKey]);
+          }
+        }
+      } else {
+        ids = idPassed ? coerceArray(idsOrFn) : null;
+      }
+      isDev() && globalState.setAction({ type: 'Remove Entity', entityId: ids });
 
-    this.setState(state => _crud._remove(state, ids));
+      return _crud._remove(state, ids);
+    });
   }
 
   /**

--- a/akita/src/internal/crud.ts
+++ b/akita/src/internal/crud.ts
@@ -76,13 +76,13 @@ export class CRUD {
       const id = ids[i];
       assertEntityExists(id, state.entities);
 
-      const newState = isFunction(newStateOrFn) ? newStateOrFn(state.entities[id]) : newStateOrFn;
-
       const oldEntity = state.entities[id];
+      const newState = isFunction(newStateOrFn) ? newStateOrFn(oldEntity) : newStateOrFn;
+
       let newEntity;
 
       const merged = {
-        ...state.entities[id],
+        ...oldEntity,
         ...newState
       };
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [O] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[X] Feature
[X] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, there was no way to easily update/remove entities based on anything other than IDs

Issue Number: #46 

## What is the new behavior?
Introduced a new overload for both, the `update` and `remove` methods that accept a predicate.
Also fixes a bug described in the comments of #46

Notice the changes in the imports. My IDE sorts them alphabetically. That's all there's to it.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
