### PR TITLE
fix(entity-dirty-check): Add boolean isSomeDirty

### DIFF
--- a/akita/__tests__/dirty-check.spec.ts
+++ b/akita/__tests__/dirty-check.spec.ts
@@ -189,15 +189,25 @@ describe('DirtyCheckEntity', () => {
     widgetsStore.add([createWidget(), createWidget(), createWidget()]);
     collection.setHead();
     const spy = jest.fn();
-    collection.isSomeDirty().subscribe(spy);
+    collection.isSomeDirty$.subscribe(spy);
+    let isDirty = collection.isSomeDirty();
+    expect(isDirty).toBe(false);
     expect(spy).toHaveBeenLastCalledWith(false);
     widgetsStore.update(5, { title: 'Changed' });
+    isDirty = collection.isSomeDirty();
+    expect(isDirty).toBe(true);
     expect(spy).toHaveBeenLastCalledWith(true);
     widgetsStore.update(4, { title: 'Changed' });
+    isDirty = collection.isSomeDirty();
+    expect(isDirty).toBe(true);
     expect(spy).toHaveBeenLastCalledWith(true);
     widgetsStore.update(4, { title: 'Widget 4' });
+    isDirty = collection.isSomeDirty();
+    expect(isDirty).toBe(true);
     expect(spy).toHaveBeenLastCalledWith(true);
     widgetsStore.update(5, { title: 'Widget 5' });
+    isDirty = collection.isSomeDirty();
+    expect(isDirty).toBe(false);
     expect(spy).toHaveBeenLastCalledWith(false);
   });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
isSomeDirty is only available as an observable<boolean>.


## What is the new behavior?
isSomeDirty is now available as boolean as well