### PR TITLE
feat(dirty-check): add support for key based check

### DIFF
--- a/akita/__tests__/dirty-check.spec.ts
+++ b/akita/__tests__/dirty-check.spec.ts
@@ -1,6 +1,7 @@
-import { DirtyCheckPlugin, EntityDirtyCheckPlugin } from '../src/index';
-import { Widget, WidgetsQuery, WidgetsStore } from './setup';
-import { Observable } from 'rxjs';
+import {DirtyCheckPlugin, EntityDirtyCheckPlugin} from '../src/index';
+import {Widget, WidgetsQuery, WidgetsStore} from './setup';
+import {Observable} from 'rxjs';
+import {skip} from "rxjs/operators";
 
 describe('DirtyCheck', () => {
   function createWidget() {
@@ -11,128 +12,181 @@ describe('DirtyCheck', () => {
   }
 
   let _id = 0;
-  const widgetsStore = new WidgetsStore();
-  const widgetsQuery = new WidgetsQuery(widgetsStore);
+  describe('Watch entire store', () => {
+    const widgetsStore = new WidgetsStore();
+    const widgetsQuery = new WidgetsQuery(widgetsStore);
 
-  it('should call activate only on first setHead()', () => {
-    spyOn(DirtyCheckPlugin.prototype, 'activate');
-    const dirtyCheck = new DirtyCheckPlugin(widgetsQuery);
+    it('should call activate only on first setHead()', () => {
+      spyOn(DirtyCheckPlugin.prototype, 'activate');
+      const dirtyCheck = new DirtyCheckPlugin(widgetsQuery);
 
-    expect(DirtyCheckPlugin.prototype.activate).not.toHaveBeenCalled();
-    dirtyCheck.setHead();
-    expect(DirtyCheckPlugin.prototype.activate).toHaveBeenCalledTimes(1);
-    dirtyCheck.setHead();
-    expect(DirtyCheckPlugin.prototype.activate).toHaveBeenCalledTimes(1);
+      expect(DirtyCheckPlugin.prototype.activate).not.toHaveBeenCalled();
+      dirtyCheck.setHead();
+      expect(DirtyCheckPlugin.prototype.activate).toHaveBeenCalledTimes(1);
+      dirtyCheck.setHead();
+      expect(DirtyCheckPlugin.prototype.activate).toHaveBeenCalledTimes(1);
+    });
+
+    describe('Plugin flow', () => {
+      const dirtyCheck = new DirtyCheckPlugin(widgetsQuery);
+      const spy = jest.fn();
+
+      dirtyCheck.isDirty$.subscribe(spy);
+
+      it('should setHead()', () => {
+        widgetsStore.add(createWidget());
+        expect(spy).toHaveBeenLastCalledWith(false);
+        dirtyCheck.setHead();
+        expect(dirtyCheck.head).toEqual({
+          entities: {
+            '1': {
+              id: 1,
+              title: 'Widget 1'
+            }
+          },
+          error: null,
+          ids: [1],
+          loading: true
+        });
+        expect(spy).toHaveBeenLastCalledWith(false);
+      });
+
+      it("should mark as dirty when the store value doesn't equal to head", () => {
+        widgetsStore.add(createWidget());
+        expect(spy).toHaveBeenLastCalledWith(true);
+      });
+
+      it('should mark as pristine when the store value equal to head', () => {
+        widgetsStore.remove(2);
+        expect(spy).toHaveBeenLastCalledWith(false);
+      });
+
+      it('should rebase the head', () => {
+        widgetsStore.add(createWidget());
+        expect(spy).toHaveBeenLastCalledWith(true);
+        dirtyCheck.setHead();
+        expect(spy).toHaveBeenLastCalledWith(false);
+        expect(dirtyCheck.head).toEqual({
+          entities: {
+            '1': {
+              id: 1,
+              title: 'Widget 1'
+            },
+            '3': {
+              id: 3,
+              title: 'Widget 3'
+            }
+          },
+
+          error: null,
+          ids: [1, 3],
+          loading: true
+        });
+      });
+
+      it('should reset the store to current head value', () => {
+        widgetsStore.add(createWidget());
+        expect(spy).toHaveBeenLastCalledWith(true);
+        dirtyCheck.reset();
+        expect(widgetsStore._value()).toEqual({
+          entities: {
+            '1': {
+              id: 1,
+              title: 'Widget 1'
+            },
+            '3': {
+              id: 3,
+              title: 'Widget 3'
+            }
+          },
+          error: null,
+          ids: [1, 3],
+          loading: true
+        });
+
+        expect(spy).toHaveBeenLastCalledWith(false);
+      });
+
+      it('should unsubscribe on destroy', () => {
+        dirtyCheck.destroy();
+        expect(dirtyCheck.subscription.closed).toBeTruthy();
+      });
+
+      it('should return true if state is dirty', () => {
+        dirtyCheck.updateDirtiness(true);
+        const isDirty = dirtyCheck.isDirty();
+        expect(isDirty).toBeTruthy();
+      });
+
+      it('should return false if state is not dirty', () => {
+        dirtyCheck.updateDirtiness(false);
+        const isDirty = dirtyCheck.isDirty();
+        expect(isDirty).toBeFalsy();
+      });
+
+      it('should return true if state has head', () => {
+        dirtyCheck.setHead();
+        const isDirty = dirtyCheck.hasHead();
+        expect(isDirty).toBeTruthy();
+      });
+
+      it('should return false if state does not has head', () => {
+        dirtyCheck.head = null;
+        const hasHead = dirtyCheck.hasHead();
+        expect(hasHead).toBeFalsy();
+      });
+    });
   });
 
-  describe('Plugin flow', () => {
-    const dirtyCheck = new DirtyCheckPlugin(widgetsQuery);
+  describe('Watch specific property', () => {
+    const widgetsStore = new WidgetsStore({name: 'akita'});
+    const widgetsQuery = new WidgetsQuery(widgetsStore);
+    const dirtyCheck = new DirtyCheckPlugin(widgetsQuery, {watchProperty: 'name'}).setHead();
     const spy = jest.fn();
+    dirtyCheck.isDirty$.pipe(skip(1)).subscribe(spy);
 
-    dirtyCheck.isDirty$.subscribe(spy);
-
-    it('should setHead()', () => {
+    it('should not trigger a change in is dirty', () => {
+      /** reset widgets ID */
+      _id = 0;
       widgetsStore.add(createWidget());
-      expect(spy).toHaveBeenLastCalledWith(false);
-      dirtyCheck.setHead();
-      expect(dirtyCheck.head).toEqual({
-        entities: {
-          '1': {
-            id: 1,
-            title: 'Widget 1'
-          }
-        },
-        error: null,
-        ids: [1],
-        loading: true
-      });
-      expect(spy).toHaveBeenLastCalledWith(false);
-    });
-
-    it("should mark as dirty when the store value doesn't equal to head", () => {
-      widgetsStore.add(createWidget());
-      expect(spy).toHaveBeenLastCalledWith(true);
-    });
-
-    it('should mark as pristine when the store value equal to head', () => {
-      widgetsStore.remove(2);
-      expect(spy).toHaveBeenLastCalledWith(false);
-    });
-
-    it('should rebase the head', () => {
-      widgetsStore.add(createWidget());
-      expect(spy).toHaveBeenLastCalledWith(true);
-      dirtyCheck.setHead();
-      expect(spy).toHaveBeenLastCalledWith(false);
-      expect(dirtyCheck.head).toEqual({
-        entities: {
-          '1': {
-            id: 1,
-            title: 'Widget 1'
-          },
-          '3': {
-            id: 3,
-            title: 'Widget 3'
-          }
-        },
-
-        error: null,
-        ids: [1, 3],
-        loading: true
-      });
-    });
-
-    it('should reset the store to current head value', () => {
-      widgetsStore.add(createWidget());
-      expect(spy).toHaveBeenLastCalledWith(true);
-      dirtyCheck.reset();
-      expect(widgetsStore._value()).toEqual({
-        entities: {
-          '1': {
-            id: 1,
-            title: 'Widget 1'
-          },
-          '3': {
-            id: 3,
-            title: 'Widget 3'
-          }
-        },
-        error: null,
-        ids: [1, 3],
-        loading: true
-      });
-
-      expect(spy).toHaveBeenLastCalledWith(false);
-    });
-
-    it('should unsubscribe on destroy', () => {
-      dirtyCheck.destroy();
-      expect(dirtyCheck.subscription.closed).toBeTruthy();
+      expect(spy).not.toHaveBeenCalled();
     });
 
     it('should return true if state is dirty', () => {
-      dirtyCheck.updateDirtiness(true);
-      const isDirty = dirtyCheck.isDirty();
-      expect(isDirty).toBeTruthy();
+      widgetsStore.updateRoot({name: 'kazaz'});
+      expect(spy).toHaveBeenLastCalledWith(true);
     });
 
-    it('should return false if state is not dirty', () => {
-      dirtyCheck.updateDirtiness(false);
-      const isDirty = dirtyCheck.isDirty();
-      expect(isDirty).toBeFalsy();
+    it('should only reset the watched property', () => {
+      widgetsStore.add(createWidget());
+      dirtyCheck.reset();
+      expect(spy).toHaveBeenLastCalledWith(false);
+      expect(widgetsStore.entities[1]).toBeDefined();
+      expect(widgetsStore.entities[2]).toBeDefined();
+      expect(widgetsStore._value().name).toBe('akita');
     });
 
-    it('should return true if state has head', () => {
-      dirtyCheck.setHead();
-      const isDirty = dirtyCheck.hasHead();
-      expect(isDirty).toBeTruthy();
+    describe('Watch entities', () => {
+      const dirtyCheck = new DirtyCheckPlugin(widgetsQuery, {watchProperty: 'entities'}).setHead();
+      it(`should watch 'ids' property if 'entities' is watched`, () => {
+        const watching = !['entities', 'ids'].some((key) => !(dirtyCheck.params.watchProperty as any[]).includes(key));
+        expect(watching).toBe(true);
+      });
+
+      it('should reset to original entities after store changes', () => {
+        dirtyCheck.setHead();
+        /** do some manipulation */
+        widgetsStore.add([createWidget(),createWidget(),createWidget()]);
+        widgetsStore.remove(1);
+        widgetsStore.updateRoot({name: 'Akita'});
+        widgetsStore.update(2, {title: 'kazaz widget'});
+        dirtyCheck.reset();
+        expect(widgetsStore.entities).toEqual({'1': {id: 1, title: 'Widget 1'}, '2': {id: 2, title: 'Widget 2'}});
+        expect(widgetsStore._value().name).toEqual('Akita');
+      });
+
     });
 
-    it('should return false if state does not has head', () => {
-      dirtyCheck.head = null;
-      const hasHead = dirtyCheck.hasHead();
-      expect(hasHead).toBeFalsy();
-    });
   });
 });
 
@@ -146,102 +200,187 @@ describe('DirtyCheckEntity', () => {
   }
 
   let _id = 0;
-  const widgetsStore = new WidgetsStore();
-  const widgetsQuery = new WidgetsQuery(widgetsStore);
-  const collection = new EntityDirtyCheckPlugin(widgetsQuery);
+  let widgetsStore = new WidgetsStore();
+  let widgetsQuery = new WidgetsQuery(widgetsStore);
+  let collection = new EntityDirtyCheckPlugin(widgetsQuery);
   widgetsStore.add([createWidget(), createWidget(), createWidget()]);
   collection.setHead();
 
-  it('should select all when not passing entityIds', () => {
-    expect(collection.entities.size).toEqual(3);
-  });
+  describe('Not passing ids', () => {
 
-  it('should work with entity', () => {
-    const spy = jest.fn();
-    collection.isDirty(1).subscribe(spy);
-    expect(spy).toHaveBeenLastCalledWith(false);
-    widgetsStore.update(2, { title: 'Changed' });
-    expect(spy).toHaveBeenLastCalledWith(false);
-    widgetsStore.update(1, { title: 'Changed' });
-    expect(spy).toHaveBeenLastCalledWith(true);
-    widgetsStore.update(1, { title: 'Widget 1' });
-    expect(spy).toHaveBeenLastCalledWith(false);
-    widgetsStore.update(1, { title: 'Changed' });
-    expect(spy).toHaveBeenLastCalledWith(true);
-    expect(widgetsQuery.getEntity(1)).toEqual({ id: 1, title: 'Changed', complete: false });
-    collection.reset(1);
-    expect(widgetsQuery.getEntity(1)).toEqual({ id: 1, title: 'Widget 1', complete: false });
-    widgetsStore.update(1, { title: 'Changed', complete: true });
-    expect(widgetsQuery.getEntity(1)).toEqual({ id: 1, title: 'Changed', complete: true });
-    const updateFn = (head, current) => {
-      return {
-        ...head,
-        title: current.title
+    it('should select all when not passing entityIds', () => {
+      expect(collection.entities.size).toEqual(3);
+    });
+
+    it('should work with entity', () => {
+      const spy = jest.fn();
+      collection.isDirty(1).subscribe(spy);
+      expect(spy).toHaveBeenLastCalledWith(false);
+      widgetsStore.update(2, {title: 'Changed'});
+      expect(spy).toHaveBeenLastCalledWith(false);
+      widgetsStore.update(1, {title: 'Changed'});
+      expect(spy).toHaveBeenLastCalledWith(true);
+      widgetsStore.update(1, {title: 'Widget 1'});
+      expect(spy).toHaveBeenLastCalledWith(false);
+      widgetsStore.update(1, {title: 'Changed'});
+      expect(spy).toHaveBeenLastCalledWith(true);
+      expect(widgetsQuery.getEntity(1)).toEqual({id: 1, title: 'Changed', complete: false});
+      collection.reset(1);
+      expect(widgetsQuery.getEntity(1)).toEqual({id: 1, title: 'Widget 1', complete: false});
+      widgetsStore.update(1, {title: 'Changed', complete: true});
+      expect(widgetsQuery.getEntity(1)).toEqual({id: 1, title: 'Changed', complete: true});
+      const updateFn = (head, current) => {
+        return {
+          ...head,
+          title: current.title
+        };
       };
-    };
-    collection.reset(1, { updateFn });
-    expect(widgetsQuery.getEntity(1)).toEqual({ id: 1, title: 'Changed', complete: false });
-    expect(spy).toHaveBeenLastCalledWith(true);
+      collection.reset(1, {updateFn});
+      expect(widgetsQuery.getEntity(1)).toEqual({id: 1, title: 'Changed', complete: false});
+      expect(spy).toHaveBeenLastCalledWith(true);
+    });
+
+    it('should return true if some of the entities are dirty', () => {
+      widgetsStore.remove();
+      widgetsStore.add([createWidget(), createWidget(), createWidget()]);
+      collection.setHead();
+      const spy = jest.fn();
+      collection.isSomeDirty$.subscribe(spy);
+      let isDirty = collection.isSomeDirty();
+      expect(isDirty).toBe(false);
+      expect(spy).toHaveBeenLastCalledWith(false);
+      widgetsStore.update(5, {title: 'Changed'});
+      isDirty = collection.isSomeDirty();
+      expect(isDirty).toBe(true);
+      expect(spy).toHaveBeenLastCalledWith(true);
+      widgetsStore.update(4, {title: 'Changed'});
+      isDirty = collection.isSomeDirty();
+      expect(isDirty).toBe(true);
+      expect(spy).toHaveBeenLastCalledWith(true);
+      widgetsStore.update(4, {title: 'Widget 4'});
+      isDirty = collection.isSomeDirty();
+      expect(isDirty).toBe(true);
+      expect(spy).toHaveBeenLastCalledWith(true);
+      widgetsStore.update(5, {title: 'Widget 5'});
+      isDirty = collection.isSomeDirty();
+      expect(isDirty).toBe(false);
+      expect(spy).toHaveBeenLastCalledWith(false);
+    });
+
+    it('should return isDirty as observable by default', () => {
+      const widget = createWidget();
+      widgetsStore.add(widget);
+      const isDirty = collection.isDirty(widget.id);
+      expect(isDirty).toBeInstanceOf(Observable);
+    });
+
+    it('should return isDirty as observable', () => {
+      const widget = createWidget();
+      widgetsStore.add(widget);
+      const isDirty = collection.isDirty(widget.id, true);
+      expect(isDirty).toBeInstanceOf(Observable);
+    });
+
+    it('should return isDirty as boolean', () => {
+      const widget = createWidget();
+      widgetsStore.add(widget);
+      const isDirty = collection.isDirty(widget.id, false);
+      expect(typeof isDirty).toEqual('boolean');
+    });
+
+    it('should return true for hasHead()', () => {
+      const widget = createWidget();
+      widgetsStore.add(widget);
+      expect(collection.hasHead(widget.id)).toBeTruthy();
+    });
   });
 
-  it('should return true if some of the entities are dirty', () => {
-    widgetsStore.remove();
+
+  describe('Passing ids', () => {
+    let widgetsStore = new WidgetsStore();
+    let widgetsQuery = new WidgetsQuery(widgetsStore);
+    _id = 0;
+    let collection = new EntityDirtyCheckPlugin(widgetsQuery, {entityIds: [1, 2]});
     widgetsStore.add([createWidget(), createWidget(), createWidget()]);
-    collection.setHead();
-    const spy = jest.fn();
-    collection.isSomeDirty$.subscribe(spy);
-    let isDirty = collection.isSomeDirty();
-    expect(isDirty).toBe(false);
-    expect(spy).toHaveBeenLastCalledWith(false);
-    widgetsStore.update(5, { title: 'Changed' });
-    isDirty = collection.isSomeDirty();
-    expect(isDirty).toBe(true);
-    expect(spy).toHaveBeenLastCalledWith(true);
-    widgetsStore.update(4, { title: 'Changed' });
-    isDirty = collection.isSomeDirty();
-    expect(isDirty).toBe(true);
-    expect(spy).toHaveBeenLastCalledWith(true);
-    widgetsStore.update(4, { title: 'Widget 4' });
-    isDirty = collection.isSomeDirty();
-    expect(isDirty).toBe(true);
-    expect(spy).toHaveBeenLastCalledWith(true);
-    widgetsStore.update(5, { title: 'Widget 5' });
-    isDirty = collection.isSomeDirty();
-    expect(isDirty).toBe(false);
-    expect(spy).toHaveBeenLastCalledWith(false);
-  });
+    collection.setHead([1,2]);
 
-  it('should return isDirty as observable by default', () => {
-    const widget = createWidget();
-    widgetsStore.add(widget);
-    const isDirty = collection.isDirty(widget.id);
-    expect(isDirty).toBeInstanceOf(Observable);
-  });
+    it('should select given ids', () => {
+      expect(collection.entities.size).toEqual(2);
+    });
 
-  it('should return isDirty as observable', () => {
-    const widget = createWidget();
-    widgetsStore.add(widget);
-    const isDirty = collection.isDirty(widget.id, true);
-    expect(isDirty).toBeInstanceOf(Observable);
-  });
+    it('should work with entity', () => {
+      const spy = jest.fn();
+      collection.isDirty(1).subscribe(spy);
+      expect(spy).toHaveBeenLastCalledWith(false);
+      widgetsStore.update(2, {title: 'Changed'});
+      expect(spy).toHaveBeenLastCalledWith(false);
+      widgetsStore.update(1, {title: 'Changed'});
+      expect(spy).toHaveBeenLastCalledWith(true);
+      widgetsStore.update(1, {title: 'Widget 1'});
+      expect(spy).toHaveBeenLastCalledWith(false);
+      widgetsStore.update(1, {title: 'Changed'});
+      expect(spy).toHaveBeenLastCalledWith(true);
+      expect(widgetsQuery.getEntity(1)).toEqual({id: 1, title: 'Changed', complete: false});
+      collection.reset(1);
+      expect(widgetsQuery.getEntity(1)).toEqual({id: 1, title: 'Widget 1', complete: false});
+      widgetsStore.update(1, {title: 'Changed', complete: true});
+      expect(widgetsQuery.getEntity(1)).toEqual({id: 1, title: 'Changed', complete: true});
+      const updateFn = (head, current) => {
+        return {
+          ...head,
+          title: current.title
+        };
+      };
+      collection.reset(1, {updateFn});
+      expect(widgetsQuery.getEntity(1)).toEqual({id: 1, title: 'Changed', complete: false});
+      expect(spy).toHaveBeenLastCalledWith(true);
+    });
 
-  it('should return isDirty as boolean', () => {
-    const widget = createWidget();
-    widgetsStore.add(widget);
-    const isDirty = collection.isDirty(widget.id, false);
-    expect(typeof isDirty).toEqual('boolean');
-  });
+    it('should return true if some of the entities are dirty', () => {
+      widgetsStore.remove();
+      _id = 3;
+      widgetsStore.add([createWidget(), createWidget(), createWidget()]);
+      collection = new EntityDirtyCheckPlugin(widgetsQuery, {entityIds: [4, 6]});
+      collection.setHead();
+      const spy = jest.fn();
+      collection.isSomeDirty$.subscribe(spy);
+      let isDirty = collection.isSomeDirty();
+      expect(isDirty).toBe(false);
+      expect(spy).toHaveBeenLastCalledWith(false);
+      widgetsStore.update(5, {title: 'Changed'});
+      isDirty = collection.isSomeDirty();
+      expect(isDirty).toBe(false);
+      expect(spy).toHaveBeenLastCalledWith(false);
+      widgetsStore.update(6, {title: 'Changed'});
+      isDirty = collection.isSomeDirty();
+      expect(isDirty).toBe(true);
+      expect(spy).toHaveBeenLastCalledWith(true);
+      widgetsStore.update(4, {title: 'Changed'});
+      isDirty = collection.isSomeDirty();
+      expect(isDirty).toBe(true);
+      expect(spy).toHaveBeenLastCalledWith(true);
+      widgetsStore.update(4, {title: 'Widget 4'});
+      isDirty = collection.isSomeDirty();
+      expect(isDirty).toBe(true);
+      expect(spy).toHaveBeenLastCalledWith(true);
+      widgetsStore.update(5, {title: 'Widget 5'});
+      isDirty = collection.isSomeDirty();
+      expect(isDirty).toBe(true);
+      expect(spy).toHaveBeenLastCalledWith(true);
+      widgetsStore.update(6, {title: 'Widget 6'});
+      isDirty = collection.isSomeDirty();
+      expect(isDirty).toBe(false);
+      expect(spy).toHaveBeenLastCalledWith(false);
+    });
 
-  it('should return false for hasHead()', () => {
-    const widget = createWidget();
-    widgetsStore.add(widget);
-    expect(collection.hasHead(widget.id)).toBeFalsy();
-  });
+    it('should return false for hasHead()', () => {
+      const widget = createWidget();
+      widgetsStore.add(widget);
+      expect(collection.hasHead(widget.id)).toBeFalsy();
+      collection.setHead(widget.id);
+      expect(collection.hasHead(widget.id)).toBeFalsy();
+    });
 
-  it('should return true for hasHead()', () => {
-    const widget = createWidget();
-    widgetsStore.add(widget);
-    collection.setHead(widget.id);
-    expect(collection.hasHead(widget.id)).toBeTruthy();
-  });
+  })
+
 });

--- a/akita/__tests__/setup.ts
+++ b/akita/__tests__/setup.ts
@@ -88,8 +88,8 @@ export type Widget = {
 };
 
 export class WidgetsStore extends EntityStore<any, Widget> {
-  constructor() {
-    super();
+  constructor(initState?) {
+    super(initState);
   }
 }
 

--- a/akita/src/plugins/dirty-check/dirty-check-plugin.ts
+++ b/akita/src/plugins/dirty-check/dirty-check-plugin.ts
@@ -1,38 +1,46 @@
 import { AkitaPlugin, Queries } from '../plugin';
 import { QueryEntity } from '../../api/query-entity';
-import { BehaviorSubject, Subscription } from 'rxjs';
-import { distinctUntilChanged, skip } from 'rxjs/operators';
-import { isFunction, isUndefined, toBoolean } from '../../internal/utils';
+import { Observable, BehaviorSubject, Subscription, merge } from 'rxjs';
+import {distinctUntilChanged, map, skip} from 'rxjs/operators';
+import {coerceArray, isFunction, isUndefined, toBoolean} from '../../internal/utils';
 import { EntityParam } from '../entity-collection-plugin';
 import { globalState } from '../../internal/global-state';
 import { Query } from '../../api/query';
-import { Observable } from 'rxjs';
 
-export type DirtyCheckComparator<E> = (head: E, current: E) => boolean;
+export type DirtyCheckComparator<Entity> = (head: Entity, current: Entity) => boolean;
 
-export type DirtyCheckParams<E = any> = {
-  comparator?: DirtyCheckComparator<E>;
+export type DirtyCheckParams<StoreState = any> = {
+  comparator?: DirtyCheckComparator<StoreState>;
+  watchProperty?: keyof StoreState | (keyof StoreState)[];
 };
 
-export const dirtyCheckDefaultParams: DirtyCheckParams = {
+export const dirtyCheckDefaultParams = {
   comparator: (head, current) => JSON.stringify(head) !== JSON.stringify(current)
 };
 
-export type DirtyCheckResetParams<S = any> = {
-  updateFn?: S | ((head: S, current: S) => any);
+export type DirtyCheckResetParams<StoreState = any> = {
+  updateFn?: StoreState | ((head: StoreState, current: StoreState) => any);
 };
 
-export class DirtyCheckPlugin<E = any, S = any> extends AkitaPlugin<E, S> {
-  private head: S | E;
+export class DirtyCheckPlugin<Entity = any, StoreState = any> extends AkitaPlugin<Entity, StoreState> {
+  private head: StoreState | Partial<StoreState> | Entity;
   private dirty = new BehaviorSubject(false);
   private subscription: Subscription;
   private active = false;
 
   isDirty$: Observable<boolean> = this.dirty.asObservable().pipe(distinctUntilChanged());
 
-  constructor(protected query: Queries<E, S>, private params?: DirtyCheckParams, private _entityId?: EntityParam) {
+  constructor(protected query: Queries<Entity, StoreState>, private params?: DirtyCheckParams, private _entityId?: EntityParam) {
     super(query);
     this.params = { ...dirtyCheckDefaultParams, ...params };
+    if (this.params.watchProperty) {
+    let watchProp = this.params.watchProperty;
+      watchProp = coerceArray(watchProp);
+      if (watchProp.includes('entities') && !watchProp.includes('ids') && query instanceof QueryEntity) {
+        watchProp.push('ids');
+      }
+      this.params.watchProperty = watchProp;
+    }
   }
 
   protected getHead() {
@@ -40,13 +48,19 @@ export class DirtyCheckPlugin<E = any, S = any> extends AkitaPlugin<E, S> {
   }
 
   private activate() {
-    this.head = this.getSource(this._entityId);
-    this.subscription = this.selectSource(this._entityId)
-      .pipe(skip(1))
+    this.head = this._getHead();
+    /** if we are tracking specific properties select only the relevant ones */
+    const source = this.params.watchProperty
+      ? (this.params.watchProperty as (keyof StoreState)[]).map(
+        (prop) => this.query.select(state => state[prop]).pipe(map((val) => ({val, __akitaKey: prop}))))
+      : [this.selectSource(this._entityId)];
+    this.subscription = merge(...source).pipe(skip(1))
       .subscribe(currentState => {
         if (isUndefined(this.head)) return;
-
-        const isChange = this.params.comparator(this.head, currentState);
+        /** __akitaKey is used to determine if we are tracking a specific property or a store change */
+        const head = currentState.__akitaKey ? this.head[currentState.__akitaKey as any] : this.head;
+        const compareTo = currentState.__akitaKey ? currentState.val : currentState;
+        const isChange = this.params.comparator(head, compareTo);
 
         this.updateDirtiness(isChange);
       });
@@ -56,13 +70,14 @@ export class DirtyCheckPlugin<E = any, S = any> extends AkitaPlugin<E, S> {
     let currentValue = this.head;
     if (isFunction(params.updateFn)) {
       if (this.isEntityBased(this._entityId)) {
-        currentValue = params.updateFn(this.head, (this.getQuery() as QueryEntity<S, E>).getEntity(this._entityId));
+        currentValue = params.updateFn(this.head, (this.getQuery() as QueryEntity<StoreState, Entity>).getEntity(this._entityId));
       } else {
-        currentValue = params.updateFn(this.head, (this.getQuery() as Query<S>).getSnapshot());
+        currentValue = params.updateFn(this.head, (this.getQuery() as Query<StoreState>).getSnapshot());
       }
     }
-
-    if (this.getSource(this._entityId) !== currentValue) {
+    /** If we are watching specific props compare them, if not compare the entire store */
+    const update = this.params.watchProperty ? this.compareProp(currentValue) : this._getHead() !== currentValue;
+    if (update) {
       globalState.setCustomAction({ type: `@DirtyCheck - Revert` });
       this.updateStore(currentValue, this._entityId);
     }
@@ -72,13 +87,14 @@ export class DirtyCheckPlugin<E = any, S = any> extends AkitaPlugin<E, S> {
     if (!this.active) {
       this.activate();
       this.active = true;
+    } else {
+      this.head = this._getHead();
     }
-    this.head = this.getSource(this._entityId);
     this.updateDirtiness(false);
     return this;
   }
 
-  isDirty() {
+  isDirty(): boolean {
     return toBoolean(this.dirty.value);
   }
 
@@ -94,4 +110,23 @@ export class DirtyCheckPlugin<E = any, S = any> extends AkitaPlugin<E, S> {
   private updateDirtiness(isDirty: boolean) {
     this.dirty.next(isDirty);
   }
+
+  private _getHead(): Partial<StoreState> | StoreState {
+    let head: StoreState | Partial<StoreState> = this.getSource(this._entityId) as StoreState;
+    if (this.params.watchProperty) {
+      head = (this.params.watchProperty as (keyof StoreState)[]).reduce((_head, prop) => {
+        _head[prop] = (head as Partial<StoreState>)[prop];
+        return _head;
+      }, {} as Partial<StoreState>) ;
+    }
+    return head;
+  }
+
+  private compareProp(currentState: Partial<StoreState>): boolean {
+    const propKeys = Object.keys(currentState);
+    const head = this._getHead();
+
+    return propKeys.some((propKey) => currentState[propKey] !== head[propKey]);
+  }
+
 }

--- a/akita/src/plugins/dirty-check/entity-dirty-check-plugin.ts
+++ b/akita/src/plugins/dirty-check/entity-dirty-check-plugin.ts
@@ -1,9 +1,9 @@
 import {HashMap, ID, IDS} from '../../api/types';
-import { DirtyCheckPlugin, DirtyCheckComparator, dirtyCheckDefaultParams, DirtyCheckResetParams } from './dirty-check-plugin';
-import { QueryEntity } from '../../api/query-entity';
-import { EntityCollectionPlugin } from '../entity-collection-plugin';
-import { skip, map } from 'rxjs/operators';
-import { Observable } from 'rxjs';
+import {DirtyCheckComparator, dirtyCheckDefaultParams, DirtyCheckPlugin, DirtyCheckResetParams} from './dirty-check-plugin';
+import {QueryEntity} from '../../api/query-entity';
+import {EntityCollectionPlugin} from '../entity-collection-plugin';
+import {map, skip} from 'rxjs/operators';
+import {Observable} from 'rxjs';
 
 export type DirtyCheckCollectionParams<E> = {
   comparator?: DirtyCheckComparator<E>;
@@ -12,16 +12,16 @@ export type DirtyCheckCollectionParams<E> = {
 
 export class EntityDirtyCheckPlugin<E, P extends DirtyCheckPlugin<E, any> = DirtyCheckPlugin<E, any>> extends EntityCollectionPlugin<E, P> {
 
-  isSomeDirty$: Observable<boolean> =  this.query.select(state => state.entities)
-    .pipe( map(entities => this.checkSomeDirty(entities)));
+  isSomeDirty$: Observable<boolean> = this.query.select(state => state.entities)
+    .pipe(map(entities => this.checkSomeDirty(entities)));
 
   constructor(protected query: QueryEntity<any, E>, private readonly params: DirtyCheckCollectionParams<E> = {}) {
     super(query, params.entityIds);
-    this.params = { ...dirtyCheckDefaultParams, ...params };
+    this.params = {...dirtyCheckDefaultParams, ...params};
     this.activate();
-    this.selectIds()
-      .pipe(skip(1))
-      .subscribe(ids => this.activate(ids));
+    this.selectIds().pipe(skip(1)).subscribe(ids => {
+      this.rebase(ids, {afterAdd: plugin => plugin.setHead()});
+    });
   }
 
   setHead(ids?: IDS) {

--- a/akita/src/plugins/plugin.ts
+++ b/akita/src/plugins/plugin.ts
@@ -50,7 +50,7 @@ export abstract class AkitaPlugin<E = any, S = any> {
     if (this.isEntityBased(entityId)) {
       this.getStore().update(entityId, newState);
     } else {
-      this.getStore().setState(() => newState);
+      this.getStore().setState((state) => ({...state, ...newState}));
     }
   }
 }

--- a/playground/src/app/nav/nav.component.ts
+++ b/playground/src/app/nav/nav.component.ts
@@ -10,21 +10,19 @@ import { Router } from '@angular/router';
     <nav>
       <div class="nav-wrapper cyan lighten-2">
         <a class="brand-logo" routerLink="/">Akita Store</a>
-
         <ul id="nav-mobile" class="right hide-on-med-and-down">
           <li *ngIf="isLoggedIn$ | async"><a (click)="logout()">Logout</a></li>
-          <li><a routerLink="todos">Todos</a></li>
-          <li><a routerLink="contacts">Contacts</a></li>
-          <li><a routerLink="stories">Stories</a></li>
-          <li><a routerLink="movies">Movies</a></li>
-          <li><a routerLink="widgets">Widgets</a></li>
-          <li><a routerLink="cart">Cart <span class="new badge">{{count$ | async}}</span></a></li>
+          <li *ngFor="let item of navItems">
+            <a routerLinkActive="blue-text text-lighten-2" [routerLink]="item.toLowerCase()">{{item}}</a>
+          </li>
+          <li><a routerLinkActive="blue-text text-lighten-2" routerLink="cart">Cart <span class="new badge">{{count$ | async}}</span></a></li>
         </ul>
       </div>
     </nav>
   `
 })
 export class NavComponent {
+  navItems = ['Todos', 'Contacts', 'Stories', 'Movies', 'Widgets'];
   count$: Observable<number>;
   isLoggedIn$: Observable<boolean>;
 

--- a/playground/src/app/widgets/state/widget.model.ts
+++ b/playground/src/app/widgets/state/widget.model.ts
@@ -17,3 +17,7 @@ export function createWidget(params?: Partial<Widget>) {
     name: `Widget ${_id}`
   } as Widget;
 }
+
+export function resetId(count?: number) {
+  _id = count || 0;
+}

--- a/playground/src/app/widgets/state/widgets.service.ts
+++ b/playground/src/app/widgets/state/widgets.service.ts
@@ -10,12 +10,25 @@ import { ID } from '../../../../../../akita/akita/src/index';
 export class WidgetsService {
   constructor(private widgetsStore: WidgetsStore, private widgetsDataService: WidgetsDataService) {}
 
-  add() {
+  initWidgets() {
     const widgets = [createWidget(), createWidget(), createWidget(), createWidget(), createWidget()];
-    this.widgetsStore.add(widgets);
+    this.widgetsStore.set(widgets);
   }
 
   updateWidget(id: ID, name: string) {
     this.widgetsStore.update(id, { name });
+  }
+
+  add() {
+    this.widgetsStore.add(createWidget());
+  }
+
+  remove(id?: ID) {
+    this.widgetsStore.remove(id);
+    this.widgetsStore.setDirty();
+  }
+
+  updateName(name: string) {
+    this.widgetsStore.updateRoot({name});
   }
 }

--- a/playground/src/app/widgets/state/widgets.store.ts
+++ b/playground/src/app/widgets/state/widgets.store.ts
@@ -2,12 +2,18 @@ import { Injectable } from '@angular/core';
 import { Widget } from './widget.model';
 import { EntityState, EntityStore, StoreConfig } from '../../../../../akita/src';
 
-export interface State extends EntityState<Widget> {}
+export interface State extends EntityState<Widget> {
+  name: string;
+}
+
+const initState = {
+  name: 'Akita widgets'
+};
 
 @Injectable({ providedIn: 'root' })
 @StoreConfig({ name: 'widgets' })
 export class WidgetsStore extends EntityStore<State, Widget> {
   constructor() {
-    super();
+    super(initState);
   }
 }

--- a/playground/src/app/widgets/widgets.component.html
+++ b/playground/src/app/widgets/widgets.component.html
@@ -1,34 +1,64 @@
-<div class="padding">
-
-  <table class="striped centered" style="width: 40%;">
-    <thead>
+<div class="padding flex flex-column">
+  <div class="flex align-center">
+    <h4 style="margin-right: 20px;">Page name: {{ dashoboardName$ | async }}</h4>
+    <input (keydown.enter)="updateName(pageName)" [value]="dashoboardName$ | async" #pageName style="width: 250px;margin-right: 20px;">
+    <button class="btn waves-effect waves-light" style="margin: 20px 10px 0 0;" (click)="updateName(pageName)">Update Name
+      <i class="material-icons right">save</i>
+    </button>
+  </div>
+  <div>
+    <h6>The dirty check plugin is only listening to widgets changes and therefore isn't effecting the page name</h6>
+  </div>
+  <div class="all-widgets-dirty-check flex flex-column flex-1 align-center">
+    <table class="striped centered padding">
+      <thead>
       <tr>
         <th>Id</th>
         <th>Name</th>
         <th>Update</th>
         <th>Revert</th>
+        <th>Delete</th>
       </tr>
-    </thead>
+      </thead>
 
-    <tbody>
+      <tbody>
       <tr *ngFor="let widget of widgets$ | async">
         <td>{{widget.id}}</td>
         <td style="width: 200px;">
-          <input [value]="widget.name" #name style="margin-right: 20px;">
+          <input (keydown.enter)="updateWidget(widget.id, name.value)" [value]="widget.name" #name style="margin-right: 20px;">
         </td>
         <td>
-          <a class="btn-floating"><i class="material-icons" (click)="updateWidget(widget.id, name.value)">save</i></a>
+          <a class="btn-floating">
+            <i class="material-icons" (click)="updateWidget(widget.id, name.value)">save</i>
+          </a>
         </td>
         <td>
-          <a class="btn-floating" [class.disabled]="!(collection.isDirty(widget.id) | async)"><i class="material-icons" (click)="revert(widget.id)">undo</i></a>
+          <a class="btn-floating"
+             [class.disabled]="!(widgetsSpecific.isDirty(widget.id) | async)">
+            <i class="material-icons" (click)="revert(widget.id)">undo</i>
+          </a>
+        </td>
+        <td>
+          <a class="btn-floating"><i class="material-icons" (click)="remove(widget.id)">delete</i></a>
         </td>
       </tr>
-    </tbody>
-  </table>
+      </tbody>
+    </table>
+    <div class="flex sb">
+      <button class="btn waves-effect waves-light" style="margin: 20px 10px 0 0;" (click)="remove()">Clear list
+        <i class="material-icons right">clear</i>
+      </button>
+      <button class="btn waves-effect waves-light" style="margin: 20px 10px 0 0;" (click)="add()">Add widget
+        <i class="material-icons right">add_circle</i>
+      </button>
+      <button class="btn waves-effect waves-light tooltipped"
+              style="margin: 20px 10px 0 0;"
+              [class.disabled]="!(collection.isDirty$ | async)"
+              (click)="revertStore()">Reset Store Entities
+        <i class="material-icons right">undo</i>
+      </button>
+    </div>
 
-
-  <button class="btn waves-effect waves-light" [class.disabled]="!(dirtyCheck.isDirty$| async)" style="margin-top: 20px;" (click)="revert()">Revert Store
-    <i class="material-icons right">undo</i>
-  </button>
+  </div>
 
 </div>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
DirtyCheckPlugin tracks the entire store only

Issue Number: N/A


## What is the new behavior?
You can pass which property of the store state you want to track

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```