### PR TITLE
fix(store): show error if missing store config

### DIFF
--- a/akita/src/api/store.ts
+++ b/akita/src/api/store.ts
@@ -124,7 +124,9 @@ export class Store<S> {
 
     if (!this.store) {
       this.store = new BehaviorSubject(this.storeValue);
-      rootDispatcher.next(nextState(this.storeName, true));
+        if (!this.storeName) console.error('did you forget to create @StoreConfig({name: something})?') 
+        rootDispatcher.next(nextState(this.storeName, true));
+        
       return;
     }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [x ] Tests for the changes have been added (for bug fixes / features)
- [ x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ x] Other... Please describe: update better error
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [#56 better error message if forget creating StoreConfig](https://github.com/datorama/akita/issues/56)


## What is the new behavior?
it should throw better error like. "did you forget to create StoreConfig({}) ?"
![screen shot 2018-08-22 at 1 36 31 pm](https://user-images.githubusercontent.com/16970990/44446822-6a6cc180-a610-11e8-8222-09054d8ad1cc.png)


## Does this PR introduce a breaking change?
```
[x ] No
```
feel free to close this issue if it not suitable with project

