### PR TITLE
fix(query): select method signature missing Observable return type

### DIFF
--- a/akita/src/api/query.ts
+++ b/akita/src/api/query.ts
@@ -18,7 +18,7 @@ export class Query<S> {
    * this.query.select()
    * this.query.select(state => state.entities)
    */
-  select<R>(project?: (store: S) => R);
+  select<R>(project?: (store: S) => R): Observable<R>;
   select(): Observable<S>;
   select<R>(project?: (store: S) => R): Observable<R | S> {
     let state = project ? project : state => state;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ X] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [ X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The return type on `query.select` when passing a predicate is no longer an `Observable` and Typescript see it as `any`.

Issue Number: 75
https://github.com/datorama/akita/issues/75

## What is the new behavior?
The return type is specified as `Observable<R>` where `R` is the return type of the predicate

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
