### PR TITLE
Feature/unset active

### DIFF
--- a/akita/src/api/entity-store.ts
+++ b/akita/src/api/entity-store.ts
@@ -1,7 +1,7 @@
 import { _crud } from '../internal/crud';
 import { AkitaImmutabilityError, assertActive } from '../internal/error';
 import { Action, __globalState } from '../internal/global-state';
-import { coerceArray, entityExists, isFunction, toBoolean } from '../internal/utils';
+import { coerceArray, entityExists, isDefined, isFunction, toBoolean } from '../internal/utils';
 import { isDev, Store } from './store';
 import { ActiveState, Entities, EntityState, HashMap, ID, Newable } from './types';
 
@@ -257,13 +257,14 @@ export class EntityStore<S extends EntityState<E>, E> extends Store<S> {
   /**
    * Set the given entity as active.
    */
-  setActive(id: ID) {
-    if (id === this._value().active) return;
-    isDev() && __globalState.setAction({ type: 'Set Active Entity', entityId: id });
+  setActive(id?: ID) {
+    const activeId = isDefined(id) ? id : null;
+    if (activeId === this._value().active) return;
+    isDev() && __globalState.setAction({ type: 'Set Active Entity', entityId: activeId });
     this.setState(state => {
       return {
         ...(state as any),
-        active: id
+        active: activeId
       };
     });
   }

--- a/akita/src/api/query-entity.ts
+++ b/akita/src/api/query-entity.ts
@@ -212,6 +212,13 @@ export class QueryEntity<S extends EntityState, E> extends Query<S> {
     return projectOrId in this.store.entities;
   }
 
+  /**
+   * Returns whether entity store has an active entity.
+   */
+  hasActive(): boolean {
+    return this.getSnapshot().active !== null;
+  }
+
   isEmpty() {
     return this.getSnapshot().ids.length === 0;
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

If you've set strict null checks it is currently not possible to reset the active state to its original status.

## What is the new behavior?

Now you can leave the argument of `setActive()` empty to reset the active entity to null.
Additionally it is possible to check if there is an active entity by a new query method (`hasActive()`).

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

If you appreciate the changes I would add tests.
