### PR TITLE
enable unset of active entity in strict null check environments

### DIFF
--- a/akita/src/api/entity-store.ts
+++ b/akita/src/api/entity-store.ts
@@ -257,7 +257,7 @@ export class EntityStore<S extends EntityState<E>, E> extends Store<S> {
   /**
    * Set the given entity as active.
    */
-  setActive(id: ID) {
+  setActive(id: ID | null) {
     if (id === this._value().active) return;
     isDev() && __globalState.setAction({ type: 'Set Active Entity', entityId: id });
     this.setState(state => {


### PR DESCRIPTION
It's now possible to call setActive(null) although your project contains strict null checks.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

If you've set strict null checks it is currently not possible to reset the active state to its original status. (#83)

## What is the new behavior?

Now it's possible to call `setActive(null)` in environments with strict null checks as well.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
