### PR TITLE
feat(entity store): allow prepend option when adding

### DIFF
--- a/akita/__tests__/entity-store.spec.ts
+++ b/akita/__tests__/entity-store.spec.ts
@@ -61,18 +61,18 @@ describe('EntitiesStore', () => {
       store.add(new Todo({ id: 1 }));
       store.add(new Todo({ id: 2 }));
       store.add(new Todo({ id: 3 }));
-      store.add(new Todo({ id: 0 }), { prepend:true });
-      store.add(new Todo({ id: 2 }), { prepend:true });
-      store.add(new Todo({ id: 44 }), { prepend:true });
-      expect(store._value().ids).toEqual([44, 0, 1, 2, 3]);
+      store.add(new Todo({ id: 4 }), { prepend:true });
+      store.add(new Todo({ id: 5 }), { prepend:true });
+      store.add(new Todo({ id: 6 }), { prepend:true });
+      expect(store._value().ids).toEqual([6, 5, 4, 1, 2, 3]);
     });
  
     it('should prepend with multi add', () => {
       store.add(new Todo({ id: 1 }));
       store.add(new Todo({ id: 2 }));
       store.add(new Todo({ id: 3 }));
-      store.add([new Todo({ id: 0 }), new Todo({ id: 2 }), new Todo({ id: 44 })], {  prepend:true });
-      expect(store._value().ids).toEqual([44, 0, 1, 2, 3]);
+      store.add([new Todo({ id: 4 }), new Todo({ id: 5 }), new Todo({ id: 6 })], {  prepend:true }); 
+      expect(store._value().ids).toEqual([6, 5, 4, 1, 2, 3]);
     });
   });
 

--- a/akita/__tests__/entity-store.spec.ts
+++ b/akita/__tests__/entity-store.spec.ts
@@ -62,7 +62,7 @@ describe('EntitiesStore', () => {
       store.add(new Todo({ id: 2 }));
       store.add(new Todo({ id: 3 }));
       store.add(new Todo({ id: 0 }), { prepend:true });
-      expect(store.entities[0].id).toEqual(0);
+      expect(Object.keys(store.entities)).toEqual([0, 1, 2, 3]);
     });
  
     it('should prepend with multi add', () => {
@@ -70,9 +70,7 @@ describe('EntitiesStore', () => {
       store.add(new Todo({ id: 2 }));
       store.add(new Todo({ id: 3 }));
       store.add([new Todo({ id: 0 }), new Todo({ id: 2 }), new Todo({ id: 44 })], {  prepend:true });
-      expect(store.entities[0].id).toEqual(0);
-      expect(store.entities[3].id).toEqual(3);
-      expect(store.entities[44].id).toEqual(44);
+      expect(Object.keys(store.entities)).toEqual([0, 1, 2, 3, 44]);
     });
   });
 

--- a/akita/__tests__/entity-store.spec.ts
+++ b/akita/__tests__/entity-store.spec.ts
@@ -62,7 +62,9 @@ describe('EntitiesStore', () => {
       store.add(new Todo({ id: 2 }));
       store.add(new Todo({ id: 3 }));
       store.add(new Todo({ id: 0 }), { prepend:true });
-      expect(Object.keys(store.entities).map(item => +item)).toEqual([0, 1, 2, 3]);
+      store.add(new Todo({ id: 2 }), { prepend:true });
+      store.add(new Todo({ id: 44 }), { prepend:true });
+      expect(store._value().ids).toEqual([44, 0, 1, 2, 3]);
     });
  
     it('should prepend with multi add', () => {
@@ -70,7 +72,7 @@ describe('EntitiesStore', () => {
       store.add(new Todo({ id: 2 }));
       store.add(new Todo({ id: 3 }));
       store.add([new Todo({ id: 0 }), new Todo({ id: 2 }), new Todo({ id: 44 })], {  prepend:true });
-      expect(Object.keys(store.entities).map(item => +item)).toEqual([0, 1, 2, 3, 44]);
+      expect(store._value().ids).toEqual([44, 0, 1, 2, 3]);
     });
   });
 

--- a/akita/__tests__/entity-store.spec.ts
+++ b/akita/__tests__/entity-store.spec.ts
@@ -61,10 +61,18 @@ describe('EntitiesStore', () => {
       store.add(new Todo({ id: 1 }));
       store.add(new Todo({ id: 2 }));
       store.add(new Todo({ id: 3 }));
-      store.add(new Todo({ id: 0 }),{prepend:true});
-      console.log('store.entities',store.entities);
-      
-      expect(store.entities[0]).toBeDefined();
+      store.add(new Todo({ id: 0 }), { prepend:true });
+      expect(store.entities[0].id).toEqual(0);
+    });
+ 
+    it('should prepend with multi add', () => {
+      store.add(new Todo({ id: 1 }));
+      store.add(new Todo({ id: 2 }));
+      store.add(new Todo({ id: 3 }));
+      store.add([new Todo({ id: 0 }), new Todo({ id: 2 }), new Todo({ id: 44 })], {  prepend:true });
+      expect(store.entities[0].id).toEqual(0);
+      expect(store.entities[3].id).toEqual(3);
+      expect(store.entities[44].id).toEqual(44);
     });
   });
 

--- a/akita/__tests__/entity-store.spec.ts
+++ b/akita/__tests__/entity-store.spec.ts
@@ -62,7 +62,7 @@ describe('EntitiesStore', () => {
       store.add(new Todo({ id: 2 }));
       store.add(new Todo({ id: 3 }));
       store.add(new Todo({ id: 0 }), { prepend:true });
-      expect(Object.keys(store.entities)).toEqual([0, 1, 2, 3]);
+      expect(Object.keys(store.entities).map(item => +item)).toEqual([0, 1, 2, 3]);
     });
  
     it('should prepend with multi add', () => {
@@ -70,7 +70,7 @@ describe('EntitiesStore', () => {
       store.add(new Todo({ id: 2 }));
       store.add(new Todo({ id: 3 }));
       store.add([new Todo({ id: 0 }), new Todo({ id: 2 }), new Todo({ id: 44 })], {  prepend:true });
-      expect(Object.keys(store.entities)).toEqual([0, 1, 2, 3, 44]);
+      expect(Object.keys(store.entities).map(item => +item)).toEqual([0, 1, 2, 3, 44]);
     });
   });
 

--- a/akita/__tests__/entity-store.spec.ts
+++ b/akita/__tests__/entity-store.spec.ts
@@ -56,6 +56,16 @@ describe('EntitiesStore', () => {
       store.add(new Todo({ id: 1 }));
       expect(store.entities[1]).toBeDefined();
     });
+   
+    it('should prepend with uid', () => {
+      store.add(new Todo({ id: 1 }));
+      store.add(new Todo({ id: 2 }));
+      store.add(new Todo({ id: 3 }));
+      store.add(new Todo({ id: 0 }),{prepend:true});
+      console.log('store.entities',store.entities);
+      
+      expect(store.entities[0]).toBeDefined();
+    });
   });
 
   describe('update', () => {

--- a/akita/src/api/entity-store.ts
+++ b/akita/src/api/entity-store.ts
@@ -3,7 +3,7 @@ import { AkitaImmutabilityError, assertActive } from '../internal/error';
 import { Action, __globalState } from '../internal/global-state';
 import { coerceArray, entityExists, isFunction, toBoolean } from '../internal/utils';
 import { isDev, Store } from './store';
-import { ActiveState, Entities, EntityState, HashMap, ID, Newable } from './types';
+import { ActiveState, Entities, EntityState, HashMap, ID, Newable, AddParams } from './types';
 
 /**
  * The Root Store that every sub store needs to inherit and
@@ -73,11 +73,11 @@ export class EntityStore<S extends EntityState<E>, E> extends Store<S> {
    * this.store.add(Entity);
    * this.store.add(Entity, { prepend: true });
    */
-  add(entities: E[] | E, addConfig ?: { prepend: boolean }) {
+  add(entities: E[] | E, params ?: AddParams) {
     const toArray = coerceArray(entities);
     if (toArray.length === 0) return;
     isDev() && __globalState.setAction({ type: 'Add Entity' });
-    this.setState(state => _crud._add<S, E>(state, toArray, this.idKey, addConfig));
+    this.setState(state => _crud._add<S, E>(state, toArray, this.idKey, params));
   }
 
   /**

--- a/akita/src/api/entity-store.ts
+++ b/akita/src/api/entity-store.ts
@@ -71,12 +71,13 @@ export class EntityStore<S extends EntityState<E>, E> extends Store<S> {
    * @example
    * this.store.add([Entity, Entity]);
    * this.store.add(Entity);
+   * this.store.add(Entity,{prepend: true});
    */
-  add(entities: E[] | E) {
+  add(entities: E[] | E,config?:{prepend: boolean}) {
     const toArray = coerceArray(entities);
     if (toArray.length === 0) return;
     isDev() && __globalState.setAction({ type: 'Add Entity' });
-    this.setState(state => _crud._add<S, E>(state, toArray, this.idKey));
+    this.setState(state => _crud._add<S, E>(state, toArray, this.idKey,config));
   }
 
   /**

--- a/akita/src/api/entity-store.ts
+++ b/akita/src/api/entity-store.ts
@@ -71,13 +71,13 @@ export class EntityStore<S extends EntityState<E>, E> extends Store<S> {
    * @example
    * this.store.add([Entity, Entity]);
    * this.store.add(Entity);
-   * this.store.add(Entity,{prepend: true});
+   * this.store.add(Entity, { prepend: true });
    */
-  add(entities: E[] | E,config?:{prepend: boolean}) {
+  add(entities: E[] | E, addConfig ?: { prepend: boolean }) {
     const toArray = coerceArray(entities);
     if (toArray.length === 0) return;
     isDev() && __globalState.setAction({ type: 'Add Entity' });
-    this.setState(state => _crud._add<S, E>(state, toArray, this.idKey,config));
+    this.setState(state => _crud._add<S, E>(state, toArray, this.idKey, addConfig));
   }
 
   /**

--- a/akita/src/api/entity-store.ts
+++ b/akita/src/api/entity-store.ts
@@ -3,7 +3,7 @@ import { AkitaImmutabilityError, assertActive } from '../internal/error';
 import { Action, __globalState } from '../internal/global-state';
 import { coerceArray, entityExists, isFunction, toBoolean } from '../internal/utils';
 import { isDev, Store } from './store';
-import { ActiveState, Entities, EntityState, HashMap, ID, Newable, AddParams } from './types';
+import { ActiveState, Entities, EntityState, HashMap, ID, Newable, AddOptions } from './types';
 
 /**
  * The Root Store that every sub store needs to inherit and
@@ -73,11 +73,11 @@ export class EntityStore<S extends EntityState<E>, E> extends Store<S> {
    * this.store.add(Entity);
    * this.store.add(Entity, { prepend: true });
    */
-  add(entities: E[] | E, params ?: AddParams) {
+  add(entities: E[] | E, options ?: AddOptions) {
     const toArray = coerceArray(entities);
     if (toArray.length === 0) return;
     isDev() && __globalState.setAction({ type: 'Add Entity' });
-    this.setState(state => _crud._add<S, E>(state, toArray, this.idKey, params));
+    this.setState(state => _crud._add<S, E>(state, toArray, this.idKey, options));
   }
 
   /**

--- a/akita/src/api/types.ts
+++ b/akita/src/api/types.ts
@@ -44,3 +44,6 @@ export type ID = number | string;
 export type IDS = ID | ID[];
 
 export type Newable<T> = { new (...args: any[]): T };
+
+/** Optional config for Store.add() to prepend entity or entities to stores */
+export type AddParams = { prepend: boolean }

--- a/akita/src/api/types.ts
+++ b/akita/src/api/types.ts
@@ -46,4 +46,4 @@ export type IDS = ID | ID[];
 export type Newable<T> = { new (...args: any[]): T };
 
 /** Optional config for Store.add() to prepend entity or entities to stores */
-export type AddParams = { prepend: boolean }
+export type AddParams = { prepend?: boolean }

--- a/akita/src/api/types.ts
+++ b/akita/src/api/types.ts
@@ -46,4 +46,4 @@ export type IDS = ID | ID[];
 export type Newable<T> = { new (...args: any[]): T };
 
 /** Optional config for Store.add() to prepend entity or entities to stores */
-export type AddParams = { prepend?: boolean }
+export type AddOptions = { prepend?: boolean }

--- a/akita/src/internal/crud.ts
+++ b/akita/src/internal/crud.ts
@@ -1,4 +1,4 @@
-import { Entities, EntityState, HashMap, ID, Newable } from '../api/types';
+import { Entities, EntityState, HashMap, ID, Newable, AddParams } from '../api/types';
 import { AkitaUpdateIdKeyError, assertEntityExists, assertEntityState } from './error';
 import { entityExists, isFunction, isPlainObject, resetActive } from './utils';
 
@@ -46,7 +46,7 @@ export class CRUD {
     };
   }
 
-  _add<S extends EntityState, E>(state: S, entities: E[], idKey, addConfig ?: { prepend: boolean }): S {
+  _add<S extends EntityState, E>(state: S, entities: E[], idKey, addConfig ?: AddParams): S {
     let addedEntities = {};
     let addedIds = [];
 

--- a/akita/src/internal/crud.ts
+++ b/akita/src/internal/crud.ts
@@ -46,7 +46,7 @@ export class CRUD {
     };
   }
 
-  _add<S extends EntityState, E>(state: S, entities: E[], idKey,config?:{prepend: boolean}): S {
+  _add<S extends EntityState, E>(state: S, entities: E[], idKey, addConfig ?: { prepend: boolean }): S {
     let addedEntities = {};
     let addedIds = [];
 
@@ -56,7 +56,7 @@ export class CRUD {
 
       if (!entityExists(entityId, state.entities)) {
         addedEntities[entityId] = entity;
-        if (config && config.prepend) addedIds.unshift(entityId);
+        if (addConfig && addConfig.prepend) addedIds.unshift(entityId);
         else addedIds.push(entityId);
       }
     }
@@ -67,7 +67,7 @@ export class CRUD {
         ...state.entities,
         ...addedEntities
       },
-      ids: [...state.ids, ...addedIds]
+      ids: addConfig && addConfig.prepend ? [ ...addedIds, ...state.ids] : [...state.ids, ...addedIds]
     };
   }
 

--- a/akita/src/internal/crud.ts
+++ b/akita/src/internal/crud.ts
@@ -46,7 +46,7 @@ export class CRUD {
     };
   }
 
-  _add<S extends EntityState, E>(state: S, entities: E[], idKey, addConfig ?: AddParams): S {
+  _add<S extends EntityState, E>(state: S, entities: E[], idKey, addConfig: AddParams = {}): S {
     let addedEntities = {};
     let addedIds = [];
 

--- a/akita/src/internal/crud.ts
+++ b/akita/src/internal/crud.ts
@@ -46,7 +46,7 @@ export class CRUD {
     };
   }
 
-  _add<S extends EntityState, E>(state: S, entities: E[], idKey, addConfig: AddParams = {}): S {
+  _add<S extends EntityState, E>(state: S, entities: E[], idKey, params: AddParams = {}): S {
     let addedEntities = {};
     let addedIds = [];
 
@@ -56,7 +56,7 @@ export class CRUD {
 
       if (!entityExists(entityId, state.entities)) {
         addedEntities[entityId] = entity;
-        if (addConfig && addConfig.prepend) addedIds.unshift(entityId);
+        if (params && params.prepend) addedIds.unshift(entityId);
         else addedIds.push(entityId);
       }
     }
@@ -67,7 +67,7 @@ export class CRUD {
         ...state.entities,
         ...addedEntities
       },
-      ids: addConfig && addConfig.prepend ? [ ...addedIds, ...state.ids] : [...state.ids, ...addedIds]
+      ids: params && params.prepend ? [ ...addedIds, ...state.ids] : [...state.ids, ...addedIds]
     };
   }
 

--- a/akita/src/internal/crud.ts
+++ b/akita/src/internal/crud.ts
@@ -67,7 +67,7 @@ export class CRUD {
         ...state.entities,
         ...addedEntities
       },
-      ids: params && params.prepend ? [ ...addedIds, ...state.ids] : [...state.ids, ...addedIds]
+      ids: params.prepend ? [ ...addedIds, ...state.ids] : [...state.ids, ...addedIds]
     };
   }
 

--- a/akita/src/internal/crud.ts
+++ b/akita/src/internal/crud.ts
@@ -1,4 +1,4 @@
-import { Entities, EntityState, HashMap, ID, Newable, AddParams } from '../api/types';
+import { Entities, EntityState, HashMap, ID, Newable, AddOptions } from '../api/types';
 import { AkitaUpdateIdKeyError, assertEntityExists, assertEntityState } from './error';
 import { entityExists, isFunction, isPlainObject, resetActive } from './utils';
 
@@ -46,7 +46,7 @@ export class CRUD {
     };
   }
 
-  _add<S extends EntityState, E>(state: S, entities: E[], idKey, params: AddParams = {}): S {
+  _add<S extends EntityState, E>(state: S, entities: E[], idKey, options: AddOptions = {}): S {
     let addedEntities = {};
     let addedIds = [];
 
@@ -56,7 +56,7 @@ export class CRUD {
 
       if (!entityExists(entityId, state.entities)) {
         addedEntities[entityId] = entity;
-        if (params && params.prepend) addedIds.unshift(entityId);
+        if (options.prepend) addedIds.unshift(entityId);
         else addedIds.push(entityId);
       }
     }
@@ -67,7 +67,7 @@ export class CRUD {
         ...state.entities,
         ...addedEntities
       },
-      ids: params.prepend ? [ ...addedIds, ...state.ids] : [...state.ids, ...addedIds]
+      ids: options.prepend ? [ ...addedIds, ...state.ids] : [...state.ids, ...addedIds]
     };
   }
 

--- a/akita/src/internal/crud.ts
+++ b/akita/src/internal/crud.ts
@@ -46,7 +46,7 @@ export class CRUD {
     };
   }
 
-  _add<S extends EntityState, E>(state: S, entities: E[], idKey): S {
+  _add<S extends EntityState, E>(state: S, entities: E[], idKey,config?:{prepend: boolean}): S {
     let addedEntities = {};
     let addedIds = [];
 
@@ -56,7 +56,8 @@ export class CRUD {
 
       if (!entityExists(entityId, state.entities)) {
         addedEntities[entityId] = entity;
-        addedIds.push(entityId);
+        if (config && config.prepend) addedIds.unshift(entityId);
+        else addedIds.push(entityId);
       }
     }
 

--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -4423,12 +4423,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4443,17 +4445,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4570,7 +4575,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4582,6 +4588,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4596,6 +4603,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4603,12 +4611,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4627,6 +4637,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4707,7 +4718,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4719,6 +4731,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4840,6 +4853,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
I can't find your doc. I can make an update if you allow me.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A
`store.add(new Todo({ id: 1 }));` cannot prepend

## What is the new behavior?
`store.add(new Todo({ id: 0 }),{prepend:true});` can prepend to the list

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
