### PR TITLE
resetStores util function

### DIFF
--- a/akita/__tests__/reset-stores.spec.ts
+++ b/akita/__tests__/reset-stores.spec.ts
@@ -2,7 +2,6 @@ import { EntityStore } from '../src/api/entity-store';
 import { Store } from '../src/api/store';
 import { resetStores } from '../src/api/store-utils';
 import { StoreConfig } from '../src/api/store-config';
-import { todosStore } from '../../playground-react/src/todos/state/todos.store';
 
 @StoreConfig({
     name: 'todos'

--- a/akita/__tests__/reset-stores.spec.ts
+++ b/akita/__tests__/reset-stores.spec.ts
@@ -2,6 +2,7 @@ import { EntityStore } from '../src/api/entity-store';
 import { Store } from '../src/api/store';
 import { resetStores } from '../src/api/store-utils';
 import { StoreConfig } from '../src/api/store-config';
+import { todosStore } from '../../playground-react/src/todos/state/todos.store';
 
 @StoreConfig({
     name: 'todos'
@@ -50,6 +51,18 @@ describe('Reset store', () => {
                 token: 'token'
             };
         });
+    });
+
+    it('should reset store state to its initial state', () => {
+        const expected = {
+            entities: {},
+            ids: [],
+            loading: true,
+            error: null
+        };
+
+        todos.reset();
+        expect(todos._value()).toEqual(expected);
     });
 
 

--- a/akita/__tests__/reset-stores.spec.ts
+++ b/akita/__tests__/reset-stores.spec.ts
@@ -1,0 +1,88 @@
+import { EntityStore } from '../src/api/entity-store';
+import { Store } from '../src/api/store';
+import { resetStores } from '../src/api/store-utils';
+import { StoreConfig } from '../src/api/store-config';
+
+@StoreConfig({
+    name: 'todos'
+})
+class TodosStore extends EntityStore<any, any> {
+    constructor() {
+        super();
+    }
+}
+
+@StoreConfig({
+    name: 'auth'
+})
+class AuthStore extends Store<any> {
+    constructor() {
+        super({
+            id: null,
+            firstName: '',
+            lastName: '',
+            token: ''
+        });
+    }
+}
+
+const todos = new TodosStore();
+const auth = new AuthStore();
+
+todos.add([{ id: 1 }]);
+auth.setState(() => {
+    return {
+        id: 1,
+        firstName: 'Netanel',
+        lastName: 'Basal',
+        token: 'token'
+    };
+});
+
+describe('Reset store', () => {
+    afterEach(() => {
+        todos.setState(() => [{ id: 1 }]);
+        auth.setState(() => {
+            return {
+                id: 1,
+                firstName: 'Netanel',
+                lastName: 'Basal',
+                token: 'token'
+            };
+        });
+    });
+
+
+    it('should reset all stores states', () => {
+        const expected = {
+            todos: {
+                entities: {},
+                ids: [],
+                loading: true,
+                error: null
+            },
+            auth: { id: null, firstName: '', lastName: '', token: '' }
+        };
+        resetStores();
+        expect({ todos: todos._value(), auth: auth._value() }).toEqual(expected);
+    });
+
+    it('should reset all stores excluding the names passed as args', () => {
+        const expected = {
+            todos: {
+                entities: {},
+                ids: [],
+                loading: true,
+                error: null
+            },
+            auth: {
+                id: 1,
+                firstName: 'Netanel',
+                lastName: 'Basal',
+                token: 'token'
+            }
+        };
+        resetStores({ exclude: ['auth'] });
+        expect({ todos: todos._value(), auth: auth._value() }).toEqual(expected);
+    });
+});

--- a/akita/src/api/store-utils.ts
+++ b/akita/src/api/store-utils.ts
@@ -1,4 +1,5 @@
 import { isNumber } from '../internal/utils';
+import { __stores__ } from './store';
 
 /**
  * @example
@@ -36,5 +37,32 @@ export function guid() {
     const r = (Math.random() * 16) | 0,
       v = c == 'x' ? r : (r & 0x3) | 0x8;
     return v.toString(16);
+  });
+}
+
+export interface ResetStoresParams {
+  /**
+   *  By default the whole state is resetted, use this param to exclude stores that you don't want to reset.
+   */
+  exclude: string[];
+}
+
+
+export function resetStores(params?: Partial<ResetStoresParams>) {
+
+  const defaults: ResetStoresParams = {
+    exclude: []
+  };
+
+  const { exclude } = Object.assign({}, defaults, params);
+  let stores = Object.keys(__stores__);
+
+  if (exclude.length > 0) {
+    stores = stores.filter(key => !params.exclude.includes(key))
+  }
+
+  stores.forEach(storeName => {
+    __stores__[storeName].setState(() => ({ ...__stores__[storeName].initialState }));
+    __stores__[storeName].setPristine();
   });
 }

--- a/akita/src/api/store.ts
+++ b/akita/src/api/store.ts
@@ -161,7 +161,7 @@ export class Store<S> {
    * Resets the store to it's initial state and set the store to a pristine state.
    */
   reset() {
-    __globalState.setAction({ type: 'Update Store' });
+    __globalState.setAction({ type: 'Reset Store' });
     this.setState(() => Object.assign({}, this._initialState));
     this.setPristine();
   }

--- a/akita/src/api/store.ts
+++ b/akita/src/api/store.ts
@@ -176,7 +176,6 @@ export class Store<S> {
     this.setState(state => {
       let value = isFunction(newStateOrId) ? newStateOrId(state) : newStateOrId;
       let merged = Object.assign({}, state, value);
-      console.log(isPlainObject(state) ? merged : new (state as any).constructor(merged));
       return isPlainObject(state) ? merged : new (state as any).constructor(merged);
     });
     this.setDirty();

--- a/akita/src/api/store.ts
+++ b/akita/src/api/store.ts
@@ -70,8 +70,8 @@ export class Store<S> {
    */
   constructor(initialState) {
     __globalState.setAction({ type: '@@INIT' });
+    this._initialState = initialState;
     __stores__[this.storeName] = this;
-    __stores__[this.storeName]._initialState = initialState;
     this.setState(() => initialState);
     rootDispatcher.next({
       type: Actions.NEW_STORE,
@@ -130,10 +130,6 @@ export class Store<S> {
     return this._isPristine;
   }
 
-  get initialState() {
-    return this._initialState;
-  }
-
   /**
    * `setState()` is the only way to update a store; It receives a callback function,
    * which gets the current state, and returns a new immutable state,
@@ -159,6 +155,15 @@ export class Store<S> {
     }
 
     this.dispatch(this.storeValue, _rootDispatcher);
+  }
+
+  /**
+   * Resets the store to it's initial state and set the store to a pristine state.
+   */
+  reset() {
+    __globalState.setAction({ type: 'Update Store' });
+    this.setState(() => Object.assign({}, this._initialState));
+    this.setPristine();
   }
 
   /**

--- a/akita/src/api/store.ts
+++ b/akita/src/api/store.ts
@@ -62,6 +62,8 @@ export class Store<S> {
 
   private _isPristine = true;
 
+  private _initialState: S;
+
   /**
    *
    * Initial the store with the state
@@ -69,6 +71,7 @@ export class Store<S> {
   constructor(initialState) {
     __globalState.setAction({ type: '@@INIT' });
     __stores__[this.storeName] = this;
+    __stores__[this.storeName]._initialState = initialState;
     this.setState(() => initialState);
     rootDispatcher.next({
       type: Actions.NEW_STORE,
@@ -125,6 +128,10 @@ export class Store<S> {
 
   get isPristine() {
     return this._isPristine;
+  }
+
+  get initialState() {
+    return this._initialState;
   }
 
   /**

--- a/playground/src/app/nav/nav.component.ts
+++ b/playground/src/app/nav/nav.component.ts
@@ -3,6 +3,7 @@ import { CartQuery } from '../cart/state';
 import { Observable } from 'rxjs';
 import { AuthQuery, AuthService } from '../auth/state';
 import { Router } from '@angular/router';
+import { resetStores } from '../../../../akita/index';
 
 @Component({
   selector: 'app-nav',
@@ -11,6 +12,7 @@ import { Router } from '@angular/router';
       <div class="nav-wrapper cyan lighten-2">
         <a class="brand-logo" routerLink="/">Akita Store</a>
         <ul id="nav-mobile" class="right hide-on-med-and-down">
+          <li><a (click)="resetStores()">Reset Stores</a></li>
           <li *ngIf="isLoggedIn$ | async"><a (click)="logout()">Logout</a></li>
           <li *ngFor="let item of navItems">
             <a routerLinkActive="blue-text text-lighten-2" [routerLink]="item.toLowerCase()">{{item}}</a>
@@ -34,5 +36,9 @@ export class NavComponent {
   logout() {
     this.authService.logout();
     this.router.navigateByUrl('login');
+  }
+
+  resetStores() {
+    resetStores();
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 104


## What is the new behavior?
resetStores function is now available via store-utils, to allow resetting all stores to their initialState as configured by the user.
the function have an excluded property as an option, an array of strings that will exclude the specific store names from the reset process.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
