### PR TITLE
feat(query-entity): provide index in filter function

### DIFF
--- a/akita/__tests__/query-entity.spec.ts
+++ b/akita/__tests__/query-entity.spec.ts
@@ -360,6 +360,15 @@ describe('getAll', () => {
     expect(result[1].title).toEqual('aaa');
   });
 
+  it('should support filter by function with index', () => {
+    const result = queryTodos.getAll({
+      filterBy: (entity, index) => index % 2 === 0
+    });
+    expect(Array.isArray(result)).toBeTruthy();
+    expect(result.length).toEqual(1);
+    expect(result[0].title).toEqual('aaa');
+  });
+
   it('should support limitTo', () => {
     const res = queryTodos.getAll({
       limitTo: 1

--- a/akita/src/api/query-entity.ts
+++ b/akita/src/api/query-entity.ts
@@ -11,7 +11,7 @@ import { ActiveState, EntityState, HashMap, ID } from './types';
 
 export interface SelectOptions<E> extends SortByOptions<E> {
   asObject?: boolean;
-  filterBy?: ((entity: E) => boolean) | undefined;
+  filterBy?: ((entity: E, index?: number) => boolean) | undefined;
   limitTo?: number;
 }
 
@@ -181,7 +181,7 @@ export class QueryEntity<S extends EntityState, E, ActiveEntity = ID> extends Qu
   /**
    * Select the store's entity collection length.
    */
-  selectCount(predicate?: (entity: E) => boolean): Observable<number> {
+  selectCount(predicate?: (entity: E, index: number) => boolean): Observable<number> {
     if (isFunction(predicate)) {
       return this.selectAll({
         filterBy: predicate
@@ -194,7 +194,7 @@ export class QueryEntity<S extends EntityState, E, ActiveEntity = ID> extends Qu
   /**
    * Get the store's entity collection length.
    */
-  getCount(predicate?: (entity: E) => boolean): number {
+  getCount(predicate?: (entity: E, index: number) => boolean): number {
     if (isFunction(predicate)) {
       return this.getAll().filter(predicate).length;
     }
@@ -261,7 +261,7 @@ function toArray<E, S extends EntityState>(state: S, options: SelectOptions<E>):
       continue;
     }
 
-    if (filterBy(entities[id])) {
+    if (filterBy(entities[id], i)) {
       arr.push(entities[id]);
     }
   }
@@ -293,7 +293,7 @@ function toMap<E>(ids: any[], entities: HashMap<E>, options: SelectOptions<E>, g
       if (!entityExists(id, entities)) {
         continue;
       }
-      if (filterBy(entities[id])) {
+      if (filterBy(entities[id], i)) {
         map[id] = entities[id];
         count++;
       }
@@ -311,7 +311,7 @@ function toMap<E>(ids: any[], entities: HashMap<E>, options: SelectOptions<E>, g
         continue;
       }
 
-      if (toBoolean(filterBy(entities[id]))) {
+      if (toBoolean(filterBy(entities[id], i))) {
         map[id] = entities[id];
       }
     }


### PR DESCRIPTION
Send current index in custom filter function to deal with it filter.

See: https://github.com/datorama/akita/issues/117

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [x ] Tests for the changes have been added (for bug fixes / features)
- [x ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The filter function filterBy provide only the current Element. 

`export interface SelectOptions<E> extends SortByOptions<E> {
  asObject?: boolean;
  filterBy?: ((entity: E) => boolean) | undefined;
  limitTo?: number;
}`

Issue Number: 117 : https://github.com/datorama/akita/issues/117 

## What is the new behavior?
Expect to have the index number. 

`export interface SelectOptions<E> extends SortByOptions<E> {
  asObject?: boolean;
  filterBy?: ((entity: E, index?: number) => boolean) | undefined;
  limitTo?: number;
}`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x ] No
```



## Other information

## What is the motivation / use case for changing the behavior?
Permit to have in filter function the index. Can be usefull, for exemple, to test, if odd or even row, to work with position in the list, or filter to get 1 element every x element : 
for exemple, to display list in 3 column, we can get 3 selectAll with modulo. 
`const colum1 = this.entityQuery.selectAll({filterBy: (entity: E, index: number) => index % 3 === 0 });
const colum2 = this.entityQuery.selectAll({filterBy: (entity: E, index: number) => index % 3 === 1 });
const colum3 = this.entityQuery.selectAll({filterBy: (entity: E, index: number) => index % 3 === 2 });
`

## Implement it
It is easy, because, we have the information on each loop. 
`for (let i = 0; i < ids.length; i++) {
    const id = ids[i];

    if (!entityExists(id, entities)) {
      continue;
    }

    if (!filterBy) {
      arr.push(entities[id]);
      continue;
    }

    if (filterBy(entities[id], i)) {
      arr.push(entities[id]);
    }
  }` 

