### PR TITLE
feat(addIfNotExist): functions to add elements, only if not exist

### DIFF
--- a/akita/__tests__/entity-store.spec.ts
+++ b/akita/__tests__/entity-store.spec.ts
@@ -46,6 +46,20 @@ describe('EntitiesStore', () => {
     });
   });
 
+  describe('createIfNotExist', () => {
+    it('should create if does not exists', () => {
+      expect(store.createIfNotExist(1, new Todo({ id: 1 }))).toEqual(true);
+      expect(store.entities[1]).toBeDefined();
+    });
+
+    it('should not create/update if exists', () => {
+      expect(store.createIfNotExist(1, new Todo({ id: 1, title: 'initial' }))).toEqual(true);
+      expect(store.entities[1]).toBeDefined();
+      expect(store.createIfNotExist(1, new Todo({ id: 1, title: 'replaced' }))).toEqual(false);
+      expect(store.entities[1].title).toEqual('initial');
+    });
+  });
+
   describe('upsert', () => {
     it('should insert if does not exists', () => {
       store.upsert(150, new Todo({ id: 150 }));
@@ -102,6 +116,39 @@ describe('EntitiesStore', () => {
       store.add(new Todo({ id: 3 }));
       store.add([new Todo({ id: 4 }), new Todo({ id: 5 }), new Todo({ id: 6 })], { prepend: true });
       expect(store._value().ids).toEqual([6, 5, 4, 1, 2, 3]);
+    });
+  });
+
+  describe('addIfNotExist', () => {
+    it('should add entity if not exist', () => {
+      store.add(new Todo({ id: 1 }));
+      expect(store.addIfNotExist(new Todo({ id: 2 }))).toEqual([{"completed": false, "id": 2, "title": "2"}]);
+      expect(store.entities[2]).toBeDefined();
+    });
+
+    it('should not add if already added', () => {
+      expect(store.addIfNotExist(new Todo({ id: 1, title: 'initial' }))).toEqual([{"completed": false, "id": 1, "title": "initial"}]);
+      expect(store.entities[1]).toBeDefined();
+      expect(store.addIfNotExist(new Todo({ id: 1, title: 'modified' }))).toEqual(false);
+      expect(store.entities[1].title).toEqual('initial');
+    });
+
+    it('should with multi add', () => {
+      store.add(new Todo({ id: 1 }));
+      store.add(new Todo({ id: 2 }));
+      store.add(new Todo({ id: 3 }));
+      const added = store.addIfNotExist([new Todo({ id: 2 }), new Todo({ id: 3 }), new Todo({ id: 4 }), new Todo({ id: 5 })]5);
+      expect(added).toEqual([{"completed": false, "id": 4, "title": "4"}, {"completed": false, "id": 5, "title": "5"}]);
+      expect(store._value().ids).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it('should with multi add with prepend', () => {
+      store.add(new Todo({ id: 1 }));
+      store.add(new Todo({ id: 2 }));
+      store.add(new Todo({ id: 3 }));
+      const added = store.addIfNotExist([new Todo({ id: 2 }), new Todo({ id: 3 }), new Todo({ id: 4 }), new Todo({ id: 5 })], { prepend: true });
+      expect(added).toEqual([{"completed": false, "id": 4, "title": "4"}, {"completed": false, "id": 5, "title": "5"}]);
+      expect(store._value().ids).toEqual([5, 4, 1, 2, 3]);
     });
   });
 

--- a/akita/src/internal/utils.ts
+++ b/akita/src/internal/utils.ts
@@ -35,6 +35,27 @@ export function entityExists<E>(id: ID, entities: HashMap<E>) {
 }
 
 /**
+ * Function to compile, only not added Entity.
+ * @param stateEntities
+ * @param entities
+ * @param idKey
+ */
+export function onlyNewEntity<E>(stateEntities: HashMap<E>, entities: E[], idKey): E[] {
+  let addedEntities: E[] = [];
+
+  for (let i = 0; i < entities.length; i++) {
+    const entity = entities[i];
+    const entityId = entity[idKey];
+
+    if (!entityExists(entityId, stateEntities)) {
+      addedEntities.push(entity);
+    }
+  }
+
+  return addedEntities;
+}
+
+/**
  * Observable that emits empty value and complete
  */
 export function noop<T>(): Observable<T> {


### PR DESCRIPTION
Only add and update the store, if their is new entity to add.

https://github.com/datorama/akita/issues/127

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
There is no function to add one or more elements only if they are not present in the store. The add method, filter the items if they are not present. But it still launches an action in the store.
There is a private function that does this but no public function

Issue Number: https://github.com/datorama/akita/issues/127


## What is the new behavior?
A function to add one or more items only if they are not present in the store. (just search with the id), and update the store, only if it does not exist.

## Does this PR introduce a breaking change?
```
[ ] Yes
[ x] No
```

