### PR TITLE
docs(readme): fix link pointing to blog-posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Akita encourages simplicity. It saves you the hassle of creating boilerplate cod
 - 🚀 See it in action on [Stackblitz](https://stackblitz.com/edit/akita-todos-app)
 - 😎 Use the [CLI](https://github.com/datorama/akita/tree/master/cli)
 - 👉 Checkout the [sample application](http://akita.surge.sh/)
-- 📖 Read the blog [posts](https://netbasal.gitbook.io/akita/entity-store/blog-posts)
+- 📖 Read the blog [posts](https://netbasal.gitbook.io/akita/general/blog-posts)
 - 🍄 Join Akita's [Gitter](https://gitter.im/akita-state-management/Lobby#) room
 ## Contributors 
 


### PR DESCRIPTION
Fix the URL of the link pointing to the blog-posts

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Current link to the blog-posts points to a page that does not exist


## What is the new behavior?

The link to the blog-posts now correctly points to the blog-posts page on the gitbook

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
