### PR TITLE
fix: add platform check for NativeScript

### DIFF
--- a/akita/src/root.ts
+++ b/akita/src/root.ts
@@ -1,2 +1,5 @@
+const isBrowser = typeof window !== 'undefined';
+const isNativeScript = typeof global !== 'undefined' && typeof (<any>global).__runtimeVersion !== 'undefined';
+
 // @internal
-export const isNotBrowser = typeof window === 'undefined';
+export const isNotBrowser = !isBrowser && !isNativeScript;


### PR DESCRIPTION
Hey folks, 
I absolutely love Akita and I think it's awesome and very delightful to use :)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
When using Akita inside [NativeScript](https://www.nativescript.org/) not all functionalities work. The reason is the `isNotBrowser` check. For example [`persistState`](https://github.com/datorama/akita/blob/master/akita/src/persistState.ts#L56) is guarded with this check.

## What is the new behavior?
 Using Akita in NativeScript apps should be similar to using it browsers. I have added a check for NativeScript when initializing `isNotBrowser`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
