### PR TITLE
feat(store,storeconfig): config for deepFreeze function

### DIFF
--- a/akita/__tests__/deepFreeze.spec.ts
+++ b/akita/__tests__/deepFreeze.spec.ts
@@ -54,7 +54,7 @@ function deepFreezeCustom(o: ComplexState) {
 
 @StoreConfig({
   name: 'complexState2',
-  deepFreezeFunction: deepFreezeCustom
+  deepFreezeFn: deepFreezeCustom
 })
 class ComplexStoreCustom extends Store<ComplexState> {
   constructor() {

--- a/akita/__tests__/deepFreeze.spec.ts
+++ b/akita/__tests__/deepFreeze.spec.ts
@@ -1,0 +1,79 @@
+import { Store } from '../src/store';
+import { StoreConfig } from '../src/storeConfig';
+import { deepFreeze } from '../src/deepFreeze';
+
+class SpecialObject {
+  specialString: string = 'special';
+  specialNumber: number = 2;
+
+  constructor(params: Partial<ComplexState>) {
+    Object.assign(this, params);
+  }
+}
+
+class ComplexState {
+  propertyString: string = '';
+  propertyNumber: number = 1;
+  specialObject: SpecialObject = new SpecialObject({});
+
+  constructor(params: Partial<ComplexState>) {
+    Object.assign(this, params);
+  }
+}
+
+@StoreConfig({
+  name: 'complexState'
+})
+class ComplexStore extends Store<ComplexState> {
+  constructor() {
+    super(new ComplexState({}));
+  }
+}
+
+const complexStore = new ComplexStore();
+
+describe('store with no custom deepFreeze', () => {
+  it('should use default function', () => {
+    expect(complexStore.deepFreeze).toEqual(deepFreeze);
+  });
+
+  it('should freeze all properties', () => {
+    expect(Object.isFrozen(complexStore._value().propertyNumber)).toBeTruthy();
+    expect(Object.isFrozen(complexStore._value().propertyString)).toBeTruthy();
+    expect(Object.isFrozen(complexStore._value().specialObject)).toBeTruthy();
+    expect(Object.isFrozen(complexStore._value().specialObject.specialNumber)).toBeTruthy();
+    expect(Object.isFrozen(complexStore._value().specialObject.specialString)).toBeTruthy();
+  });
+});
+
+function deepFreezeCustom(o: ComplexState) {
+  Object.freeze(o);
+
+  return o;
+}
+
+@StoreConfig({
+  name: 'complexState2',
+  deepFreezeFunction: deepFreezeCustom
+})
+class ComplexStoreCustom extends Store<ComplexState> {
+  constructor() {
+    super(new ComplexState({}));
+  }
+}
+
+const complexStoreCustom = new ComplexStoreCustom();
+
+describe('store with custom deepFreeze', () => {
+  it('should use custom function', () => {
+    expect(complexStoreCustom.deepFreeze).toEqual(deepFreezeCustom);
+  });
+
+  it('should not freeze all properties', () => {
+    expect(Object.isFrozen(complexStoreCustom._value().propertyNumber)).toBeTruthy();
+    expect(Object.isFrozen(complexStoreCustom._value().propertyString)).toBeTruthy();
+    expect(Object.isFrozen(complexStoreCustom._value().specialObject)).toBeFalsy();
+    expect(Object.isFrozen(complexStoreCustom._value().specialObject.specialNumber)).toBeTruthy();
+    expect(Object.isFrozen(complexStoreCustom._value().specialObject.specialString)).toBeTruthy();
+  });
+});

--- a/akita/src/store.ts
+++ b/akita/src/store.ts
@@ -134,13 +134,18 @@ export class Store<S> {
   }
 
   // @internal
+  get deepFreeze() {
+    return this.config.deepFreezeFunction || this.options.deepFreezeFunction || deepFreeze;
+  }
+
+  // @internal
   get cacheConfig() {
     return this.config.cache || this.options.cache;
   }
 
   // @internal
   _setState(newStateFn: (state: Readonly<S>) => S, _dispatchAction = true) {
-    this.storeValue = __DEV__ ? deepFreeze(newStateFn(this._value())) : newStateFn(this._value());
+    this.storeValue = __DEV__ ? this.deepFreeze(newStateFn(this._value())) : newStateFn(this._value());
 
     if (!this.store) {
       this.store = new BehaviorSubject(this.storeValue);

--- a/akita/src/store.ts
+++ b/akita/src/store.ts
@@ -135,7 +135,7 @@ export class Store<S> {
 
   // @internal
   get deepFreeze() {
-    return this.config.deepFreezeFunction || this.options.deepFreezeFunction || deepFreeze;
+    return this.config.deepFreezeFn || this.options.deepFreezeFn || deepFreeze;
   }
 
   // @internal

--- a/akita/src/storeConfig.ts
+++ b/akita/src/storeConfig.ts
@@ -4,6 +4,7 @@ export type StoreConfigOptions = {
   idKey?: string;
   storeName?: string;
   cache?: { ttl: number };
+  deepFreezeFunction?: (o: any) => any;
 };
 
 export type UpdatableStoreConfigOptions = {

--- a/akita/src/storeConfig.ts
+++ b/akita/src/storeConfig.ts
@@ -4,7 +4,7 @@ export type StoreConfigOptions = {
   idKey?: string;
   storeName?: string;
   cache?: { ttl: number };
-  deepFreezeFunction?: (o: any) => any;
+  deepFreezeFn?: (o: any) => any;
 };
 
 export type UpdatableStoreConfigOptions = {


### PR DESCRIPTION
Adds deepFreezeFunction in StoreConfigOptions and unit tests for feature
Can use custom deepFreeze for complex objects in store

Resolves #124

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X ] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [X ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Objects in store are frozen with deepFreeze on _setState. Complex states or entities might break when frozen (like moment.js) during development.

Issue Number: #124


## What is the new behavior?
User can now add a custom deepFreeze function to dictate Freezing behavior during development.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Also added a simple unit test for deepFreeze function. Where do I update docs?