### PR TITLE
[Paginator-Plugin] Add a config property for not clear the original store when clearCache is called or cacheTimeout emits

### DIFF
--- a/akita/__tests__/pagination.spec.ts
+++ b/akita/__tests__/pagination.spec.ts
@@ -236,7 +236,7 @@ describe('Paginator', () => {
     });
   });
 
-  describe('clear cache', () => {
+  describe('clear cache as default behaviour', () => {
     it('it clear the provided page', () => {
       requestFunc.mockClear();
       paginator.setPage(3);
@@ -257,6 +257,14 @@ describe('Paginator', () => {
       expect(requestFunc).toHaveBeenCalledTimes(2);
       paginator.setPage(2);
       expect(requestFunc).toHaveBeenCalledTimes(2);
+    });
+    it('it should not clear the store when explicit stated', () => {
+      store.set(data);
+      expect(query.getAll().length).toBeGreaterThan(0);
+      let initialLength = query.getAll().length;
+      paginator.clearCache({ clearStore: false });
+      let lengthAfterCacheClear = query.getAll().length;
+      expect(initialLength).toEqual(lengthAfterCacheClear);
     });
   });
 });
@@ -289,7 +297,7 @@ describe('cacheTimeout', () => {
     )
     .subscribe();
 
-  it('should clear cache when cacheTimeout emits', () => {
+  it('should clear cache when cacheTimeout emits as default behaviour', () => {
     spyOn(paginator2, 'clearCache').and.callThrough();
     expect(query2.getAll().length).toEqual(10);
     expect(requestFunc).toHaveBeenCalledTimes(1);
@@ -299,5 +307,50 @@ describe('cacheTimeout', () => {
     expect(paginator2.hasPage(1)).toBeTruthy();
     expect(requestFunc).toHaveBeenCalledTimes(2);
     expect(paginator2.clearCache).toHaveBeenCalledTimes(1);
+  });
+});
+
+let store3 = new TodosStore();
+
+class Todos3Query extends QueryEntity<any, Todo> {
+  constructor() {
+    super(store3);
+  }
+}
+
+describe('cacheTimeout and clearStoreWithCache false', () => {
+  jest.useFakeTimers();
+  const query3 = new Todos3Query();
+  const paginator3 = new PaginatorPlugin(query3, { cacheTimeout: timer(15000), clearStoreWithCache: false });
+  const requestFunc = jest.fn();
+
+  paginator3.pageChanges
+    .pipe(
+      switchMap(page => {
+        const req = requestFunc.mockReturnValue(
+          getContacts({
+            page,
+            perPage: 10
+          })
+        );
+        return paginator3.getPage(req);
+      })
+    )
+    .subscribe();
+
+  it('it should not clear store when cacheTimeout emits', () => {
+    spyOn(paginator3, 'clearCache').and.callThrough();
+    expect(query3.getAll().length).toEqual(10);
+    expect(requestFunc).toHaveBeenCalledTimes(1);
+    jest.runAllTimers();
+    expect(paginator3.clearCache).toHaveBeenCalledTimes(1);
+    expect(query3.getAll().length).toEqual(10);
+  });
+
+  it('clearCache should clear the store when explicit stated', () => {
+    store3.set(data);
+    expect(query3.getAll().length).toBeGreaterThan(0);
+    paginator3.clearCache({ clearStore: true });
+    expect(query3.getAll().length).toEqual(0);
   });
 });

--- a/akita/__tests__/pagination.spec.ts
+++ b/akita/__tests__/pagination.spec.ts
@@ -238,13 +238,12 @@ describe('Paginator', () => {
 
   describe('clear cache', () => {
     it('it clear the provided page', () => {
-      paginator.clearCache(3);
       requestFunc.mockClear();
-      expect(paginator.pages.get(3)).toBeUndefined();
       paginator.setPage(3);
       expect(requestFunc).toHaveBeenCalledTimes(1);
-      paginator.setPage(3);
-      expect(requestFunc).toHaveBeenCalledTimes(1);
+      expect(paginator.hasPage(3)).toBeTruthy();
+      paginator.clearPage(3);
+      expect(paginator.hasPage(3)).toBeFalsy();
     });
     it('it should clear all', () => {
       paginator.clearCache();

--- a/akita/src/plugins/paginator/paginatorPlugin.ts
+++ b/akita/src/plugins/paginator/paginatorPlugin.ts
@@ -23,13 +23,15 @@ export type PaginatorConfig = {
   range?: boolean;
   startWith?: number;
   cacheTimeout?: Observable<number>;
+  clearStoreWithCache?: boolean;
 };
 
 const paginatorDefaults: PaginatorConfig = {
   pagesControls: false,
   range: false,
   startWith: 1,
-  cacheTimeout: undefined
+  cacheTimeout: undefined,
+  clearStoreWithCache: true,
 };
 
 export class PaginatorPlugin<E> extends AkitaPlugin<E> {
@@ -148,10 +150,14 @@ export class PaginatorPlugin<E> extends AkitaPlugin<E> {
   /**
    * Clear the cache.
    */
-  clearCache(options: { clearStore: boolean } = { clearStore: true }) {
+  clearCache(options: { clearStore?: boolean } = {}) {
     if (!this.initial) {
       logAction('@Pagination - Clear Cache');
-      options.clearStore && this.getStore().remove();
+
+      if (options.clearStore !== false && (this.config.clearStoreWithCache || options.clearStore)) {
+        this.getStore().remove();
+      }
+
       this.pages = new Map();
       this.metadata = new Map();
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

This changes are based on a change previously added in be88f3e9. 

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Problem was that this changes did not affect the call of clearCache when cacheTimeout emits. To cover this, and give a future-proof solution to affect the way on how clearCache interacts with the store a property has been added to paginator config.
Further, to not break existing implementations and, as most important, to keep the option to negate the initial config value if desired, the option parameter in clearCache method is kept.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
