### PR TITLE
fix(paginator): take current page from response

### DIFF
--- a/akita/src/plugins/paginator/paginatorPlugin.ts
+++ b/akita/src/plugins/paginator/paginatorPlugin.ts
@@ -31,7 +31,7 @@ const paginatorDefaults: PaginatorConfig = {
   range: false,
   startWith: 1,
   cacheTimeout: undefined,
-  clearStoreWithCache: true,
+  clearStoreWithCache: true
 };
 
 export class PaginatorPlugin<E> extends AkitaPlugin<E> {
@@ -243,13 +243,14 @@ export class PaginatorPlugin<E> extends AkitaPlugin<E> {
    * Get the current page if it's in cache, otherwise invoke the request
    */
   getPage(req: () => Observable<PaginationResponse<E>>) {
-    const page = this.pagination.currentPage;
+    let page = this.pagination.currentPage;
     if (this.hasPage(page)) {
       return this.selectPage(page);
     } else {
       this.setLoading(true);
       return from(req()).pipe(
         switchMap((config: PaginationResponse<E>) => {
+          page = config.currentPage;
           applyTransaction(() => {
             this.setLoading(false);
             this.update(config);
@@ -272,7 +273,7 @@ export class PaginatorPlugin<E> extends AkitaPlugin<E> {
   }
 
   private getTo() {
-    if(this.isLast) {
+    if (this.isLast) {
       return this.pagination.total;
     }
     return this.currentPage * this.pagination.perPage;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
1. Use server-side pagination + filters (10 rows / page)
2. Go to any(not 1) page
3. Apply filter, which filtered dataset to 5 rows at all
4. Get an error:
> Cannot read property 'ids' of undefined
>     at MapSubscriber.project (datorama-akita.js:4455).




## What is the new behavior?
Method getPage now takes page from server response, and we don't have errors.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information

I tried to write tests, but have problem with it. I cannot verify filter switching with combineLatest. In real world case it's work.