### PR TITLE
Implement OnDestroy

### DIFF
--- a/examples/angular-ecommerce/src/app/products/products-page/products-page.component.ts
+++ b/examples/angular-ecommerce/src/app/products/products-page/products-page.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { combineLatest, EMPTY, Observable } from 'rxjs';
 import { BaseProduct } from '../state/product.model';
 import { ProductsService } from '../state/products.service';
@@ -9,7 +9,7 @@ import { untilDestroyed } from 'ngx-take-until-destroy';
 @Component({
   templateUrl: './products-page.component.html'
 })
-export class ProductsPageComponent implements OnInit {
+export class ProductsPageComponent implements OnInit, OnDestroy {
   isLoading$: Observable<boolean>;
   products$: Observable<BaseProduct[]>;
 


### PR DESCRIPTION
```
[ x ] Bugfix
```

## What is the current behavior?
When component doesn't implement OnDestroy, ngOnDestroy is never called. Unsubscription doesn't happen, possible memory leak if someone copies this example.

## What is the new behavior?
Unsubscribes when the component is destroyed.

## Other information

Ngx-take-until-destroy does not work unless someone calls ngOnDestroy, hence OnDestroy must be implemented.