### PR TITLE
Fix generated service for regular Store in CLI

### DIFF
--- a/cli/plopfile.js
+++ b/cli/plopfile.js
@@ -82,7 +82,7 @@ module.exports = function(plop) {
         type: 'add',
         skipIfExists: true,
         path: buildPath(`{{'dashCase' name}}.service.${extension}`, directory, folderName),
-        templateFile: `./templates/${templateBase}/service.tpl`
+        templateFile: `./templates/${templateBase}/${templateBase === 'angular' && data.isEntityStore ? 'entity-service' : 'service'}.tpl`
       });
 
       if (template !== 'js') {

--- a/cli/templates/angular/entity-service.tpl
+++ b/cli/templates/angular/entity-service.tpl
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { {{pascalCase name}}Store } from './{{dashCase name}}.store';
+import { HttpClient } from '@angular/common/http';
+import { tap } from 'rxjs/operators';
+
+@Injectable({ providedIn: 'root' })
+export class {{pascalCase name}}Service {
+
+  constructor(private {{camelCase name}}Store: {{pascalCase name}}Store,
+              private http: HttpClient) {
+  }
+
+  get() {
+    return this.http.get('').pipe(tap(entities => this.{{camelCase name}}Store.set(entities)));
+  }
+}

--- a/cli/templates/angular/service.tpl
+++ b/cli/templates/angular/service.tpl
@@ -11,6 +11,6 @@ export class {{pascalCase name}}Service {
   }
 
   get() {
-    return this.http.get('').pipe(tap(entities => this.{{camelCase name}}Store.set(entities)));
+    return this.http.get('').pipe(tap(entities => this.{{camelCase name}}Store.update(entities)));
   }
 }


### PR DESCRIPTION
This change to the template fixes error in the generate file because "set" method is only present in EntityStore, not in regular Store.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Service generated by the CLI uses the wrong method to insert in the store. The "set" method is not present in regular Store, only in EntityStore.

Issue Number: N/A


## What is the new behavior?
Use "update" method to set the value of the store.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
