### PR TITLE
feat(upsert-many): add akitaPreCheckEntity hook

### DIFF
--- a/akita/src/entityStore.ts
+++ b/akita/src/entityStore.ts
@@ -241,16 +241,17 @@ export class EntityStore<S extends EntityState = any, EntityType = getEntityType
 
     // Update the state directly to optimize performance
     for (const entity of entities) {
-      const id = entity[this.idKey];
+      const withPreCheckHook = this.akitaPreCheckEntity(entity);
+      const id = withPreCheckHook[this.idKey];
       if (hasEntity(this.entities, id)) {
         const prev = this._value().entities[id];
-        const next = { ...this._value().entities[id], ...entity };
+        const next = { ...this._value().entities[id], ...withPreCheckHook };
         const withHook = this.akitaPreUpdateEntity(prev, next);
         const nextId = withHook[this.idKey];
         updatedEntities[nextId] = withHook;
         updatedIds.push(nextId);
       } else {
-        const newEntity = options.baseClass ? new options.baseClass(entity) : entity;
+        const newEntity = options.baseClass ? new options.baseClass(withPreCheckHook) : withPreCheckHook;
         const withHook = this.akitaPreAddEntity(newEntity);
         const nextId = withHook[this.idKey];
         addedIds.push(nextId);
@@ -521,6 +522,11 @@ export class EntityStore<S extends EntityState = any, EntityType = getEntityType
 
   // @internal
   akitaPreAddEntity(newEntity: Readonly<EntityType>): EntityType {
+    return newEntity;
+  }
+
+  // @internal
+  akitaPreCheckEntity(newEntity: Readonly<EntityType>): EntityType {
     return newEntity;
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
_Sorry, didn't find a place to update the docs_


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #248 


## What is the new behavior?
`EntityStore.upsertMany()` now calls a new hook `akitaPreCheckEntity` prior to checking if the store already has the entity.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
