### PR TITLE
Fixed Typescript errors when generating feature

### DIFF
--- a/schematics/src/ng-g/service/files/__name@dasherize__.service.ts
+++ b/schematics/src/ng-g/service/files/__name@dasherize__.service.ts
@@ -13,8 +13,8 @@ export class <%= classify(name) %>Service {
   }
 <% if (!plain) { %>
   get() {
-    return this.http.get('https://api.com').pipe(tap(entities => {
-      this.<%= camelize(name) %>Store.set(entities)
+    return this.http.get<<%= singular(classify(name)) %>[]>('https://api.com').pipe(tap(entities => {
+      this.<%= camelize(name) %>Store.set(entities);
     }));
   }
 


### PR DESCRIPTION
Added generic type to HttpClient get() method and semicolon to fix initial entity service generation.

Initial:
<img width="642" alt="Screen Shot 2019-07-30 at 11 21 06 AM" src="https://user-images.githubusercontent.com/15056748/62147233-b615f980-b2bc-11e9-8681-4ed00cade30f.png">

Fixed:
<img width="740" alt="Screen Shot 2019-07-30 at 11 21 25 AM" src="https://user-images.githubusercontent.com/15056748/62147240-b7dfbd00-b2bc-11e9-9714-643d8bf49ca9.png">


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Typescript errors on initial feature generation

Issue Number: N/A


## What is the new behavior?

Semicolon and generic type added.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
