### PR TITLE
Allow to change instance name visible in devtools

### DIFF
--- a/akita/src/devtools.ts
+++ b/akita/src/devtools.ts
@@ -6,6 +6,8 @@ import { capitalize } from './captialize';
 import { isNotBrowser } from './root';
 
 export type DevtoolsOptions = {
+  /** instance name visible in devtools */
+  name: string;
   /**  maximum allowed actions to be stored in the history tree */
   maxAge: number;
   latency: number;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
_u just need add this information in gitbook if u accept this PR_

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature ?
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```
I think its feature but i'm not 100% sure 😔

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Now if we have multiple projects with Akita, in devtools we see many 'Akita' instances to choose and debug. This is a bit annoying and confusing.

Issue Number: N/A

## What is the new behavior?
Now u can change instance name in `akitaDevTools`. With angular looks like this:
`environment.production ? [] : AkitaNgDevtools.forRoot({
      name: 'Custom instance name'
    }),`

![image](https://user-images.githubusercontent.com/5169399/63334460-c52c1c80-c33b-11e9-85a7-a42106df857b.png)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
