### PR TITLE
refactor: queryEntity selectMany

### DIFF
--- a/akita/__tests__/queryEntity.spec.ts
+++ b/akita/__tests__/queryEntity.spec.ts
@@ -129,9 +129,11 @@ describe('Entities Query', () => {
     });
 
     it('should not throw when the entity does not exists', () => {
-      sub = query.selectEntity(2, entity => entity.title).subscribe(entity => {
-        expect(entity).toBe(undefined);
-      });
+      sub = query
+        .selectEntity(2, entity => entity.title)
+        .subscribe(entity => {
+          expect(entity).toBe(undefined);
+        });
     });
 
     it('should select by predicate', () => {
@@ -140,7 +142,7 @@ describe('Entities Query', () => {
       store.add(factory());
       const spy = jest.fn();
       query.selectEntity(e => e.id === 1).subscribe(spy);
-      expect(spy).toHaveBeenCalledWith({"complete": false, "id": 1, "title": "Todo 1"});
+      expect(spy).toHaveBeenCalledWith({ complete: false, id: 1, title: 'Todo 1' });
       store.remove(1);
       expect(spy).toHaveBeenCalledWith(undefined);
     });
@@ -365,7 +367,6 @@ describe('Entities Query', () => {
     });
 
     describe('without TTL', () => {
-
       describe('selectHasCache', () => {
         it('should work in a full flow', () => {
           sub = query.selectHasCache().subscribe(spy);
@@ -420,8 +421,6 @@ describe('Entities Query', () => {
       });
     });
   });
-
-
 
   describe('hasEntity', () => {
     it('should have entity', () => {
@@ -665,34 +664,30 @@ describe('Many', () => {
   describe('SelectMany', () => {
     it('should select many', () => {
       queryTodos.selectMany([0, 1]).subscribe(spy);
-      todosStore.add(createTodos(3));
-      jest.runAllTimers();
       expect(spy).toHaveBeenCalledTimes(1);
+
+      todosStore.add(createTodos(3));
+      expect(spy).toHaveBeenCalledTimes(2);
       expect(spy).toHaveBeenCalledWith(createTodos(2));
     });
 
     it('should not fire when a different entity change', () => {
       todosStore.add(createTodos(3));
       queryTodos.selectMany([0, 1]).subscribe(spy);
-      jest.runAllTimers();
       expect(spy).toHaveBeenCalledTimes(1);
       expect(spy).toHaveBeenCalledWith(createTodos(2));
       todosStore.update(2, { completed: true });
-      jest.runAllTimers();
       expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('should work with function projection', () => {
       todosStore.add(createTodos(3));
       queryTodos.selectMany([0, 1], entity => entity.title).subscribe(spy);
-      jest.runAllTimers();
       expect(spy).toHaveBeenCalledTimes(1);
       expect(spy).toHaveBeenCalledWith(['Todo 0', 'Todo 1']);
       todosStore.update(2, { completed: true });
-      jest.runAllTimers();
       expect(spy).toHaveBeenCalledTimes(1);
       todosStore.update(1, { title: 'new title' });
-      jest.runAllTimers();
       expect(spy).toHaveBeenCalledTimes(2);
       expect(spy).toHaveBeenCalledWith(['Todo 0', 'new title']);
     });

--- a/akita/src/mapSkipUndefined.ts
+++ b/akita/src/mapSkipUndefined.ts
@@ -1,0 +1,10 @@
+// @internal
+export function mapSkipUndefined<T, V>(arr: T[], callbackFn: (value: T, index: number, array: T[]) => V) {
+  return arr.reduce((result, value, index, array) => {
+    const val = callbackFn(value, index, array);
+    if (val !== undefined) {
+      result.push(val);
+    }
+    return result;
+  }, []);
+}

--- a/akita/src/queryEntity.ts
+++ b/akita/src/queryEntity.ts
@@ -17,6 +17,7 @@ import { EntityAction, EntityActions } from './entityActions';
 import { isUndefined } from './isUndefined';
 import { QueryConfigOptions } from './queryConfig';
 import { distinctUntilArrayItemChanged } from './arrayFind';
+import { mapSkipUndefined } from './mapSkipUndefined';
 
 /**
  *
@@ -131,8 +132,7 @@ export class QueryEntity<S extends EntityState, EntityType = getEntityType<S>, I
     if (!ids || !ids.length) return of([]);
 
     return this.select(state => state.entities).pipe(
-      map(entities => ids.map(id => getEntity(id, project)(entities))),
-      map((entities): R[] | EntityType[] => entities.filter(Boolean)),
+      map(entities => mapSkipUndefined(ids, id => getEntity(id, project)(entities))),
       distinctUntilArrayItemChanged()
     ) as Observable<R[] | EntityType[]>;
   }

--- a/akita/src/queryEntity.ts
+++ b/akita/src/queryEntity.ts
@@ -134,7 +134,7 @@ export class QueryEntity<S extends EntityState, EntityType = getEntityType<S>, I
     return this.select(state => state.entities).pipe(
       map(entities => mapSkipUndefined(ids, id => getEntity(id, project)(entities))),
       distinctUntilArrayItemChanged()
-    ) as Observable<R[] | EntityType[]>;
+    );
   }
 
   /**

--- a/akita/src/queryEntity.ts
+++ b/akita/src/queryEntity.ts
@@ -1,5 +1,5 @@
-import { combineLatest, Observable, of } from 'rxjs';
-import { auditTime, distinctUntilChanged, filter, map, switchMap } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
+import { distinctUntilChanged, filter, map, switchMap } from 'rxjs/operators';
 import { isDefined } from './isDefined';
 import { EntityStore } from './entityStore';
 import { Query } from './query';
@@ -16,6 +16,7 @@ import { findEntityByPredicate, getEntity } from './getEntity';
 import { EntityAction, EntityActions } from './entityActions';
 import { isUndefined } from './isUndefined';
 import { QueryConfigOptions } from './queryConfig';
+import { distinctUntilArrayItemChanged } from './arrayFind';
 
 /**
  *
@@ -129,12 +130,11 @@ export class QueryEntity<S extends EntityState, EntityType = getEntityType<S>, I
   selectMany<R>(ids: IDType[], project?: (entity: EntityType) => R): Observable<EntityType[] | R[]> {
     if (!ids || !ids.length) return of([]);
 
-    const entities = ids.map(id => this.selectEntity(id, project));
-
-    return combineLatest(entities).pipe(
-      map(v => v.filter(Boolean)),
-      auditTime(0)
-    );
+    return this.select(state => state.entities).pipe(
+      map(entities => ids.map(id => getEntity(id, project)(entities))),
+      map((entities): R[] | EntityType[] => entities.filter(Boolean)),
+      distinctUntilArrayItemChanged()
+    ) as Observable<R[] | EntityType[]>;
   }
 
   /**


### PR DESCRIPTION
SelectMany no longer uses observables for each entity, but listens to store changes directly.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
  Not necessary


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #286 


## What is the new behavior?
`selectMany` now directly listens to changes of the state. By using `distinctUntilArrayChanged()`, it is still possible to only emit new values if the array content really changes. This way, we don't have to use `auditTime(0)`, which makes it behave like the other select methods.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
