### PR TITLE
feature(QOL): Allow the calling of upsertMany without being forced to…

### DIFF
--- a/akita/src/entityStore.ts
+++ b/akita/src/entityStore.ts
@@ -269,7 +269,7 @@ export class EntityStore<S extends EntityState = any, EntityType = getEntityType
         ...state.entities,
         ...updatedEntities
       },
-      loading: !!options.loading
+      ...(options.loading == undefined ? undefined : { loading: options.loading })
     }));
 
     updatedIds.length && this.entityActions.next({ type: EntityActions.Update, ids: updatedIds });


### PR DESCRIPTION
… update the loading state

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently when you upsert many it will by default set the loading to false, this is frustrating when trying to store some values from another service into a not initialised store.

Issue Number: N/A


## What is the new behavior?
When passing in no options into the 'entityStore.upsertMany()' it will now not change the loading state unless a value is passed for options.loading

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

if someone is relying on the loading to be updated by upsertMany they will have to change the calling to include the options of setting loading.
