### PR TITLE
fix(persist-state): Allow in non-browser

### DIFF
--- a/akita/src/persistState.ts
+++ b/akita/src/persistState.ts
@@ -10,6 +10,7 @@ import { setValue } from './setValueByString';
 import { $$addStore, $$deleteStore } from './dispatchers';
 import { isNil } from './isNil';
 import { isObject } from './isObject';
+import { isNotBrowser } from './root';
 
 let skipStorageUpdate = false;
 
@@ -44,6 +45,8 @@ function observify(asyncOrValue: any) {
 export interface PersistStateParams {
   /** The storage key */
   key: string;
+  /** Whether to enable persistState in a non-browser environment */
+  enableInNonBrowser: boolean;
   /** Storage strategy to use. This defaults to LocalStorage but you can pass SessionStorage or anything that implements the StorageEngine API. */
   storage: PersistStateStorage;
   /** Custom deserializer. Defaults to JSON.parse */
@@ -72,9 +75,9 @@ export interface PersistStateParams {
 }
 
 export function persistState(params?: Partial<PersistStateParams>) {
-
   const defaults: PersistStateParams = {
     key: 'AkitaStores',
+    enableInNonBrowser: false,
     storage: typeof localStorage === 'undefined' ? params.storage : localStorage,
     deserialize: JSON.parse,
     serialize: JSON.stringify,
@@ -92,11 +95,13 @@ export function persistState(params?: Partial<PersistStateParams>) {
     preStorageUpdateOperator: () => source => source
   };
 
-  const { storage, deserialize, serialize, include, exclude, key, preStorageUpdate, persistOnDestroy, preStorageUpdateOperator, preStoreUpdate, skipStorageUpdate } = Object.assign(
+  const { storage, enableInNonBrowser, deserialize, serialize, include, exclude, key, preStorageUpdate, persistOnDestroy, preStorageUpdateOperator, preStoreUpdate, skipStorageUpdate } = Object.assign(
     {},
     defaults,
     params
   );
+
+  if (isNotBrowser && !enableInNonBrowser) return;
 
   const hasInclude = include.length > 0;
   const hasExclude = exclude.length > 0;

--- a/akita/src/persistState.ts
+++ b/akita/src/persistState.ts
@@ -8,7 +8,6 @@ import { getValue } from './getValueByString';
 import { setAction } from './actions';
 import { setValue } from './setValueByString';
 import { $$addStore, $$deleteStore } from './dispatchers';
-import { isNotBrowser } from './root';
 import { isNil } from './isNil';
 import { isObject } from './isObject';
 
@@ -73,7 +72,6 @@ export interface PersistStateParams {
 }
 
 export function persistState(params?: Partial<PersistStateParams>) {
-  if (isNotBrowser) return;
 
   const defaults: PersistStateParams = {
     key: 'AkitaStores',


### PR DESCRIPTION
Allow `persistState` in non-browser environments.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`persistState` currently cannot be called outside of a browser environment.

Issue Number: N/A

## What is the new behavior?

Added the `enableInNonBrowser` option which defaults to `false` to optionally allow `persistState` to run outside of a browser environment.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
