### PR TITLE
fix(entity-query): selectEntityAction typing

### DIFF
--- a/akita/src/queryEntity.ts
+++ b/akita/src/queryEntity.ts
@@ -301,9 +301,9 @@ export class QueryEntity<S extends EntityState, EntityType = getEntityType<S>, I
    *
    *  this.query.selectEntityAction();
    */
-  selectEntityAction(action: EntityActions): Observable<ID[]>;
-  selectEntityAction(): Observable<EntityAction<EntityType>>;
-  selectEntityAction(action?: EntityActions): Observable<ID[] | EntityAction<EntityType>> {
+  selectEntityAction(action: EntityActions): Observable<IDType[]>;
+  selectEntityAction(): Observable<EntityAction<IDType>>;
+  selectEntityAction(action?: EntityActions): Observable<IDType[] | EntityAction<IDType>> {
     if (isUndefined(action)) {
       return this.store.selectEntityAction$;
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The typing of `selectEntityAction` currently does not use the generic `IDType` parameter.

Issue Number: N/A


## What is the new behavior?

The typing of `selectEntityAction` now uses the generic `IDType` parameter for all the overloads.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
