### PR TITLE
fix(root): fix isNotBrowser check

### DIFF
--- a/akita/src/root.ts
+++ b/akita/src/root.ts
@@ -1,2 +1,3 @@
 export const isBrowser = typeof window !== 'undefined';
 export const isNotBrowser = !isBrowser;
+export const isNativeScript = typeof global !== 'undefined' && (<any>global).__runtimeVersion !== 'undefined';

--- a/akita/src/root.ts
+++ b/akita/src/root.ts
@@ -1,5 +1,2 @@
 export const isBrowser = typeof window !== 'undefined';
-export const isNativeScript = typeof global !== 'undefined' && typeof (<any>global).__runtimeVersion !== 'undefined';
-
-// @internal
-export const isNotBrowser = !isBrowser && !isNativeScript;
+export const isNotBrowser = !isBrowser;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The `isNativeScript` is incorrect since it check for the property __runtimeVersion of the result of `typeof`. The `typeof` shouldn't be there.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

The `isNativeScript` constant is now correct and it's removed from the `isNotBrowser` check. However, now `isNativeScript` isn't used anywhere. Maybe we can simply remove the constant? This could however be a breaking change for people importing the constant; this seems unlikely though, since the check is wrong now anyway.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
