### PR TITLE
fix(with-transaction): improve typings

### DIFF
--- a/akita/src/transaction.ts
+++ b/akita/src/transaction.ts
@@ -114,7 +114,7 @@ export function transaction() {
  * )
  *
  */
-export function withTransaction<T>(transactionFn: Function) {
+export function withTransaction<T>(next: (value: T) => void) {
   return function(source: Observable<T>): Observable<T> {
     return source.pipe(tap(value => applyTransaction(() => transactionFn(value))));
   };


### PR DESCRIPTION
Previously the type of the provided value when using `withTransaction` would be any. Now its using the same pattern as rxjs library to ensure proper typing.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
Typing support for `withTransaction`

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The type of the value provided when using `withTransaction` was `any`.

## What is the new behavior?
The type of the value provided when using `withTransaction` is now the same as the type of the input Observable.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

