### PR TITLE
feat(context): release the entry type of akitaPreUpdateEntity

### DIFF
--- a/akita/src/entityStore.ts
+++ b/akita/src/entityStore.ts
@@ -520,8 +520,8 @@ export class EntityStore<S extends EntityState = any, EntityType = getEntityType
   }
 
   // @internal
-  akitaPreUpdateEntity(_: Readonly<EntityType>, nextEntity: Readonly<EntityType>): EntityType {
-    return nextEntity;
+  akitaPreUpdateEntity(_: Readonly<EntityType>, nextEntity: any): EntityType {
+    return nextEntity as EntityType;
   }
 
   // @internal


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The type of the entry argument of the function akitaPreUpdateEntity () must be the same as the type of the store.
The type of return must be the same as that of the store

## What is the new behavior?

The entry argument type of the function akitaPreUpdateEntity () is free but the return type must always be the same as the type of the store.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
