### PR TITLE
fix(formsmanager.unsubscribe): update store before unsubscribing

### DIFF
--- a/angular/playground/projects/ng-forms-manager/src/lib/forms-manager-options.ts
+++ b/angular/playground/projects/ng-forms-manager/src/lib/forms-manager-options.ts
@@ -1,0 +1,13 @@
+import { InjectionToken } from '@angular/core';
+
+export type FormsManagerOptions = {
+  debounceTime: number;
+  updateStoreOnUnsubscribe: boolean;
+};
+
+export const FORMS_MANAGER_OPTIONS = new InjectionToken<FormsManagerOptions>('FormsManagerOptions');
+
+export const defaultOptions: FormsManagerOptions = {
+  debounceTime: 300,
+  updateStoreOnUnsubscribe: false
+};

--- a/angular/playground/projects/ng-forms-manager/src/lib/forms-manager.ts
+++ b/angular/playground/projects/ng-forms-manager/src/lib/forms-manager.ts
@@ -22,17 +22,15 @@ export type ArrayControlFactory = (value: any) => AbstractControl;
   providedIn: 'root'
 })
 export class AkitaNgFormsManager<FormsState = any> {
+  private readonly _options: FormsManagerOptions;
   private readonly _store: FormsStore<FormsState>;
   private readonly _query: FormsQuery<FormsState>;
 
   private valueChanges: HashMap<Subscription> = {};
   private ngForms: HashMap<AbstractControl> = {};
 
-  private options: FormsManagerOptions;
-
   constructor(@Optional() @Inject(FORMS_MANAGER_OPTIONS) options: Partial<FormsManagerOptions> = {}) {
-    this.options = Object.assign({}, defaultOptions, options);
-
+    this._options = Object.assign({}, defaultOptions, options);
     this._store = new FormsStore({} as FormsState);
     this._query = new FormsQuery(this.store);
   }
@@ -127,7 +125,7 @@ export class AkitaNgFormsManager<FormsState = any> {
       persistForm?: boolean;
     } = {}
   ) {
-    const merged = { ...{ debounceTime: this.options.debounceTime, emitEvent: false }, ...config };
+    const merged = { ...{ debounceTime: this._options.debounceTime, emitEvent: false }, ...config };
 
     /** If the form already exist, patch the form with the store value */
     if (this.hasForm(formName) === true) {
@@ -164,7 +162,7 @@ export class AkitaNgFormsManager<FormsState = any> {
   unsubscribe(formName?: keyof FormsState, config: { removeNgForm?: boolean; updateStore?: boolean } = {}) {
     const _config = {
       removeNgForm: true,
-      ...{ updateStore: this.options.updateStoreOnUnsubscribe },
+      ...{ updateStore: this._options.updateStoreOnUnsubscribe },
       ...config
     };
     const _formName = formName as any;
@@ -174,8 +172,8 @@ export class AkitaNgFormsManager<FormsState = any> {
       if (this.valueChanges[_formName]) {
         this.valueChanges[_formName].unsubscribe();
         delete this.valueChanges[_formName];
-        if (config.updateStore && this.hasForm(name)) {
-          this.updateStore(name, this.getNgForm(name));
+        if (config.updateStore && this.hasForm(_formName)) {
+          this.updateStore(_formName, this.getNgForm(_formName));
         }
         removeInstance(_formName);
       }

--- a/angular/playground/projects/ng-forms-manager/src/lib/forms-manager.ts
+++ b/angular/playground/projects/ng-forms-manager/src/lib/forms-manager.ts
@@ -120,6 +120,7 @@ export class AkitaNgFormsManager<FormsState = any> {
       emitEvent?: boolean;
       arrControlFactory?: ArrayControlFactory | HashMap<ArrayControlFactory>;
       persistForm?: boolean;
+      updateStoreOnUnsubscribe?: boolean;
     } = {}
   ) {
     const merged = { ...{ debounceTime: 300, emitEvent: false }, ...config };
@@ -148,7 +149,9 @@ export class AkitaNgFormsManager<FormsState = any> {
       const innerSubscription = formChanges$.subscribe();
       () => {
         innerSubscription.unsubscribe();
-        this.updateStore(formName, form);
+        if (config.updateStoreOnUnsubscribe) {
+          this.updateStore(formName, form);
+        }
       };
     }).subscribe();
 

--- a/angular/playground/projects/ng-forms-manager/src/lib/forms-manager.ts
+++ b/angular/playground/projects/ng-forms-manager/src/lib/forms-manager.ts
@@ -172,7 +172,7 @@ export class AkitaNgFormsManager<FormsState = any> {
       if (this.valueChanges[_formName]) {
         this.valueChanges[_formName].unsubscribe();
         delete this.valueChanges[_formName];
-        if (config.updateStore && this.hasForm(_formName)) {
+        if (config.updateStore && this.ngForms[_formName]) {
           this.updateStore(_formName, this.getNgForm(_formName));
         }
         removeInstance(_formName);
@@ -180,7 +180,7 @@ export class AkitaNgFormsManager<FormsState = any> {
     } else {
       for (const name of Object.keys(this.valueChanges) as any[]) {
         this.valueChanges[name].unsubscribe();
-        if (config.updateStore && this.hasForm(name)) {
+        if (config.updateStore && this.ngForms[name]) {
           this.updateStore(name, this.getNgForm(name));
         }
         removeInstance(name);

--- a/angular/playground/projects/ng-forms-manager/src/lib/forms-manager.ts
+++ b/angular/playground/projects/ng-forms-manager/src/lib/forms-manager.ts
@@ -142,7 +142,7 @@ export class AkitaNgFormsManager<FormsState = any> {
       tap(() => this.updateStore(formName, form))
     );
 
-    /** wrapping formChanges ensures synced with the store when unsubscribing
+    /** wrapping formChanges ensures form state is synced with the store when unsubscribing
      *  as debounce might prevent last update from reaching the store */
     this.valueChanges[formName as any] = Observable.create(observer => {
       const innerSubscription = formChanges$.subscribe();

--- a/angular/playground/projects/ng-forms-manager/src/lib/forms-manager.ts
+++ b/angular/playground/projects/ng-forms-manager/src/lib/forms-manager.ts
@@ -5,6 +5,7 @@ import { merge, Observable, Subscription } from 'rxjs';
 import { debounceTime, distinctUntilChanged, map } from 'rxjs/operators';
 import { FormsQuery } from './forms-manager.query';
 import { FormsStore } from './forms-manager.store';
+import { FormsManagerOptions, FORMS_MANAGER_OPTIONS, defaultOptions } from './forms-manager-options';
 
 export type AkitaAbstractControl = Pick<
   AbstractControl,
@@ -16,18 +17,6 @@ export interface AkitaAbstractGroup<C = any> extends AkitaAbstractControl {
 }
 
 export type ArrayControlFactory = (value: any) => AbstractControl;
-
-export type FormsManagerOptions = {
-  debounceTime: number;
-  updateStoreOnUnsubscribe: boolean;
-};
-
-export const FORMSMANAGER_OPTIONS = new InjectionToken<FormsManagerOptions>('FormsManagerOptions');
-
-const defaultOptions: Partial<FormsManagerOptions> & { debounceTime: number; updateStoreOnUnsubscribe: boolean } = {
-  debounceTime: 300,
-  updateStoreOnUnsubscribe: false
-};
 
 @Injectable({
   providedIn: 'root'
@@ -41,7 +30,7 @@ export class AkitaNgFormsManager<FormsState = any> {
 
   private options: FormsManagerOptions;
 
-  constructor(@Optional() @Inject(FORMSMANAGER_OPTIONS) options: Partial<FormsManagerOptions> = {}) {
+  constructor(@Optional() @Inject(FORMS_MANAGER_OPTIONS) options: Partial<FormsManagerOptions> = {}) {
     this.options = Object.assign({}, defaultOptions, options);
 
     this._store = new FormsStore({} as FormsState);
@@ -185,15 +174,15 @@ export class AkitaNgFormsManager<FormsState = any> {
       if (this.valueChanges[_formName]) {
         this.valueChanges[_formName].unsubscribe();
         delete this.valueChanges[_formName];
-        if (config.updateStore) {
-          this.updateStore(formName, this.getNgForm(_formName));
+        if (config.updateStore && this.hasForm(name)) {
+          this.updateStore(name, this.getNgForm(name));
         }
         removeInstance(_formName);
       }
     } else {
       for (const name of Object.keys(this.valueChanges) as any[]) {
         this.valueChanges[name].unsubscribe();
-        if (config.updateStore) {
+        if (config.updateStore && this.hasForm(name)) {
           this.updateStore(name, this.getNgForm(name));
         }
         removeInstance(name);

--- a/angular/playground/projects/ng-forms-manager/src/public-api.ts
+++ b/angular/playground/projects/ng-forms-manager/src/public-api.ts
@@ -1,3 +1,4 @@
 export * from './lib/forms-manager';
+export { FORMS_MANAGER_OPTIONS, FormsManagerOptions } from './lib/forms-manager-options';
 export * from './lib/forms-manager.store';
 export * from './lib/forms-manager.query';


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
https://github.com/datorama/akita/issues/343

Issue Number: 343


## What is the new behavior?
Store gets updated when calling `formManger.unsubscribe()`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

