### PR TITLE
fix(store): fix resettable getter condition to return boolean

### DIFF
--- a/akita/__tests__/resetStores.spec.ts
+++ b/akita/__tests__/resetStores.spec.ts
@@ -119,7 +119,6 @@ describe('Reset store', () => {
       category: 'New Category'
     }));
 
-    console.log(getAkitaConfig());
     resetStores();
 
     expect(uiStore.getValue()).toEqual({

--- a/akita/__tests__/resetStores.spec.ts
+++ b/akita/__tests__/resetStores.spec.ts
@@ -1,8 +1,8 @@
+import { akitaConfig, getAkitaConfig } from '../src/config';
 import { EntityStore } from '../src/entityStore';
-import { Store } from '../src/store';
 import { resetStores } from '../src/resetStores';
+import { Store } from '../src/store';
 import { StoreConfig } from '../src/storeConfig';
-import { akitaConfig } from '../src/config';
 
 akitaConfig({
   resettable: true
@@ -31,8 +31,19 @@ class AuthStore extends Store<any> {
   }
 }
 
+@StoreConfig({ name: 'ui', resettable: false })
+class UiStore extends Store {
+  constructor() {
+    super({
+      isChecked: false,
+      category: 'Category'
+    });
+  }
+}
+
 const todos = new TodosStore();
 const auth = new AuthStore();
+const uiStore = new UiStore();
 
 todos.add([{ id: 1 }]);
 auth._setState(() => {
@@ -100,5 +111,20 @@ describe('Reset store', () => {
     };
     resetStores({ exclude: ['auth'] });
     expect({ todos: todos._value(), auth: auth._value() }).toEqual(expected);
+  });
+
+  it('should not reset store if resettable = true in global and false on decorator', () => {
+    uiStore.update(state => ({
+      isChecked: true,
+      category: 'New Category'
+    }));
+
+    console.log(getAkitaConfig());
+    resetStores();
+
+    expect(uiStore.getValue()).toEqual({
+      isChecked: true,
+      category: 'New Category'
+    });
   });
 });

--- a/akita/src/store.ts
+++ b/akita/src/store.ts
@@ -1,18 +1,19 @@
-import { StoreCache, UpdateStateCallback } from './types';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { distinctUntilChanged, map } from 'rxjs/operators';
-import { assertStoreHasName } from './errors';
-import { commit, isTransactionInProcess } from './transaction';
-import { deepFreeze } from './deepFreeze';
-import { configKey, StoreConfigOptions, UpdatableStoreConfigOptions } from './storeConfig';
-import { getAkitaConfig } from './config';
-import { isPlainObject } from './isPlainObject';
-import { isFunction } from './isFunction';
-import { dispatchAdded, dispatchDeleted, dispatchUpdate } from './dispatchers';
-import { __stores__ } from './stores';
 import { resetCustomAction, setAction } from './actions';
-import { isBrowser } from './root';
+import { getAkitaConfig } from './config';
+import { deepFreeze } from './deepFreeze';
+import { dispatchAdded, dispatchDeleted, dispatchUpdate } from './dispatchers';
 import { __DEV__, isDev } from './env';
+import { assertStoreHasName } from './errors';
+import { isFunction } from './isFunction';
+import { isPlainObject } from './isPlainObject';
+import { isBrowser } from './root';
+import { configKey, StoreConfigOptions, UpdatableStoreConfigOptions } from './storeConfig';
+import { __stores__ } from './stores';
+import { toBoolean } from './toBoolean';
+import { commit, isTransactionInProcess } from './transaction';
+import { StoreCache, UpdateStateCallback } from './types';
 
 /**
  *
@@ -161,7 +162,7 @@ export class Store<S = any> {
 
   // @internal
   get resettable() {
-    return this.config.resettable || this.options.resettable;
+    return toBoolean(this.config.resettable) || toBoolean(this.options.resettable);
   }
 
   // @internal


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, if the user provides `resettable: false` in the StoreConfig decorator but it it is set globally in `akitaConfig` with `resettable: true`, the store will be reset.
This is caused due to `resettable` getter returning `undefined` when `options.resettable` was not provided.


## What is the new behavior?
`get resettable()` will always return a boolean thus preferring the decorator config over the global

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
