### PR TITLE
fix(store): fix resettable to not return always false, closes #359

### DIFF
--- a/akita/src/store.ts
+++ b/akita/src/store.ts
@@ -6,6 +6,7 @@ import { deepFreeze } from './deepFreeze';
 import { dispatchAdded, dispatchDeleted, dispatchUpdate } from './dispatchers';
 import { __DEV__, isDev } from './env';
 import { assertStoreHasName } from './errors';
+import { isDefined } from './isDefined';
 import { isFunction } from './isFunction';
 import { isPlainObject } from './isPlainObject';
 import { isBrowser } from './root';
@@ -162,7 +163,7 @@ export class Store<S = any> {
 
   // @internal
   get resettable() {
-    return toBoolean(this.config.resettable) || toBoolean(this.options.resettable);
+    return isDefined(this.config.resettable) ? this.config.resettable : this.options.resettable;
   }
 
   // @internal


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
`resettable` always returning false, therefore global config is never checked

Issue Number: 359

## What is the new behavior?
check if config has `resettable` defined first, otherwise return it from options without boolean coercion


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
