### PR TITLE
feat(query-entity): support single active state

### DIFF
--- a/akita/__tests__/queryEntity.spec.ts
+++ b/akita/__tests__/queryEntity.spec.ts
@@ -230,6 +230,14 @@ describe('Entities Query', () => {
       store.setActive(undefined);
       expect(query.hasActive()).toBeFalsy();
     });
+
+    it('should have single active entity', () => {
+      let todo = cot();
+      store.add(todo);
+      store.setActive(1);
+      expect(query.hasActive()).toBeTruthy();
+      expect(query.hasActive(1)).toBeTruthy();
+    });
   });
 
   describe('selectCount', () => {

--- a/akita/src/queryEntity.ts
+++ b/akita/src/queryEntity.ts
@@ -1,23 +1,23 @@
 import { Observable, of } from 'rxjs';
 import { distinctUntilChanged, filter, map, switchMap } from 'rxjs/operators';
-import { isDefined } from './isDefined';
-import { EntityStore } from './entityStore';
-import { Query } from './query';
-import { EntityState, HashMap, ID, ItemPredicate, OrArray, SelectOptions, getEntityType, getIDType } from './types';
-import { isFunction } from './isFunction';
-import { toBoolean } from './toBoolean';
-import { sortByOptions } from './sortByOptions';
+import { distinctUntilArrayItemChanged } from './arrayFind';
 import { entitiesToArray } from './entitiesToArray';
 import { entitiesToMap } from './entitiesToMap';
-import { SelectAllOptionsA, SelectAllOptionsB, SelectAllOptionsC, SelectAllOptionsD, SelectAllOptionsE } from './selectAllOverloads';
-import { isArray } from './isArray';
-import { isNil } from './isNil';
-import { findEntityByPredicate, getEntity } from './getEntity';
 import { EntityAction, EntityActions } from './entityActions';
+import { EntityStore } from './entityStore';
+import { findEntityByPredicate, getEntity } from './getEntity';
+import { isArray } from './isArray';
+import { isDefined } from './isDefined';
+import { isFunction } from './isFunction';
+import { isNil } from './isNil';
 import { isUndefined } from './isUndefined';
-import { QueryConfigOptions } from './queryConfig';
-import { distinctUntilArrayItemChanged } from './arrayFind';
 import { mapSkipUndefined } from './mapSkipUndefined';
+import { Query } from './query';
+import { QueryConfigOptions } from './queryConfig';
+import { SelectAllOptionsA, SelectAllOptionsB, SelectAllOptionsC, SelectAllOptionsD, SelectAllOptionsE } from './selectAllOverloads';
+import { sortByOptions } from './sortByOptions';
+import { toBoolean } from './toBoolean';
+import { EntityState, getEntityType, getIDType, HashMap, ItemPredicate, OrArray, SelectOptions } from './types';
 
 /**
  *
@@ -354,13 +354,14 @@ export class QueryEntity<S extends EntityState, EntityType = getEntityType<S>, I
    */
   hasActive(id?: IDType): boolean {
     const active = this.getValue().active;
+    const isIdProvided = isDefined(id);
     if (Array.isArray(active)) {
-      if (isDefined(id)) {
+      if (isIdProvided) {
         return active.includes(id);
       }
       return active.length > 0;
     }
-    return isDefined(active);
+    return (isIdProvided && active === id) || isDefined(active);
   }
 
   /**


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, `hasActive` does not support single `ActiveState` 

## What is the new behavior?
`hasActive` will now also check single active id

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
