### PR TITLE
fix(state-history): fix jump past and future

### DIFF
--- a/akita/__tests__/stateHistory.spec.ts
+++ b/akita/__tests__/stateHistory.spec.ts
@@ -141,15 +141,15 @@ describe('StateHistory', () => {
     expect(stateHistory.history).toEqual({
       past: [{ counter: 0 }],
       present: { counter: 1 },
-      future: [{ counter: 2 }, { counter: 3 }, { counter: 4 }]
+      future: [{ counter: 2 }, { counter: 3 }, { counter: 4 }, { counter: 5 }]
     });
 
     stateHistory.jumpToFuture(1);
 
     expect(stateHistory.history).toEqual({
-      past: [{ counter: 0 }, { counter: 2 }],
+      past: [{ counter: 0 }, { counter: 1 }, { counter: 2 }],
       present: { counter: 3 },
-      future: [{ counter: 4 }]
+      future: [{ counter: 4 }, { counter: 5 }]
     });
 
     stateHistory.ignoreNext();
@@ -161,9 +161,9 @@ describe('StateHistory', () => {
     });
 
     expect(stateHistory.history).toEqual({
-      past: [{ counter: 0 }, { counter: 2 }],
+      past: [{ counter: 0 }, { counter: 1 }, { counter: 2 }],
       present: { counter: 3 },
-      future: [{ counter: 4 }]
+      future: [{ counter: 4 }, { counter: 5 }]
     });
 
     store._setState(state => {
@@ -173,17 +173,17 @@ describe('StateHistory', () => {
     });
 
     expect(stateHistory.history).toEqual({
-      past: [{ counter: 0 }, { counter: 2 }, { counter: 4 }],
+      past: [{ counter: 0 }, { counter: 1 }, { counter: 2 }, { counter: 4 }],
       present: { counter: 5 },
-      future: [{ counter: 4 }]
+      future: [{ counter: 4 }, { counter: 5 }]
     });
 
     stateHistory.ignoreNext();
 
     expect(stateHistory.history).toEqual({
-      past: [{ counter: 0 }, { counter: 2 }, { counter: 4 }],
+      past: [{ counter: 0 }, { counter: 1 }, { counter: 2 }, { counter: 4 }],
       present: { counter: 5 },
-      future: [{ counter: 4 }]
+      future: [{ counter: 4 }, { counter: 5 }]
     });
 
     stateHistory.clear(history => {
@@ -195,7 +195,7 @@ describe('StateHistory', () => {
     });
 
     expect(stateHistory.history).toEqual({
-      past: [{ counter: 0 }, { counter: 2 }, { counter: 4 }],
+      past: [{ counter: 0 }, { counter: 1 }, { counter: 2 }, { counter: 4 }],
       present: { counter: 5 },
       future: []
     });

--- a/akita/src/plugins/stateHistory/stateHistoryPlugin.ts
+++ b/akita/src/plugins/stateHistory/stateHistoryPlugin.ts
@@ -137,18 +137,21 @@ export class StateHistoryPlugin<State = any> extends AkitaPlugin<State> {
   jumpToPast(index: number) {
     if (index < 0 || index >= this.history.past.length) return;
 
-    const { past, future } = this.history;
+    const { past, future, present } = this.history;
     /**
      *
      * const past = [1, 2, 3, 4, 5];
+     * const present = 6;
+     * const future = [7, 8, 9];
+     * const index = 2;
      *
-     * newPast = past.slice(0, 2) = [1, 2];
-     * present = past[index] = 3;
-     * [...past.slice(2 + 1), ...future] = [4, 5];
+     * newPast = past.slice(0, index) = [1, 2];
+     * newPresent = past[index] = 3;
+     * newFuture = [...past.slice(index + 1),present, ...future] = [4, 5, 6, 7, 8, 9];
      *
      */
     const newPast = past.slice(0, index);
-    const newFuture = [...past.slice(index + 1), ...future];
+    const newFuture = [...past.slice(index + 1), present, ...future];
     const newPresent = past[index];
     this.history.past = newPast;
     this.history.present = newPresent;
@@ -159,12 +162,23 @@ export class StateHistoryPlugin<State = any> extends AkitaPlugin<State> {
   jumpToFuture(index: number) {
     if (index < 0 || index >= this.history.future.length) return;
 
-    const { past, future } = this.history;
+    const { past, future, present } = this.history;
+    /**
+     *
+     * const past = [1, 2, 3, 4, 5];
+     * const present = 6;
+     * const future = [7, 8, 9, 10]
+     * const index = 1
+     *
+     * newPast = [...past, present, ...future.slice(0, index) = [1, 2, 3, 4, 5, 6, 7];
+     * newPresent = future[index] = 8;
+     * newFuture = futrue.slice(index+1) = [9, 10];
+     *
+     */
 
-    const newPast = [...past, ...future.slice(0, index)];
+    const newPast = [...past, present, ...future.slice(0, index)];
     const newPresent = future[index];
     const newFuture = future.slice(index + 1);
-
     this.history.past = newPast;
     this.history.present = newPresent;
     this.history.future = newFuture;


### PR DESCRIPTION
Jump to past and jump to future were dropping the present state

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When calling jumpToPast(n) for the history plugin, the present state was not added to the "future". Similarly, when calling jumpToFuture(n), the present wasn't added to the past.

## What is the new behavior?
The present is not lost when navigating back and forth.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
[Discussion in medium](https://medium.com/@georgebark/netanel-basal-first-of-all-great-work-loving-akita-b88b905101d1)