### PR TITLE
fix: 🐛 persist form should merge the state

### DIFF
--- a/akita/__tests__/persistForm.spec.ts
+++ b/akita/__tests__/persistForm.spec.ts
@@ -109,6 +109,43 @@ describe('PersistForm - key based', () => {
   });
 });
 
+describe('PersistForm - key based nested key', () => {
+  @StoreConfig({ name: 'stories' })
+  class StoriesStore extends EntityStore<any, any> {
+    constructor() {
+      super({ config: { form: { name: '', isAdmin: false, type: 'type' } } });
+    }
+  }
+
+  class StoriesQuery extends QueryEntity<any, Story> {
+    constructor(protected store) {
+      super(store);
+    }
+  }
+
+  const store = new StoriesStore();
+  const query = new StoriesQuery(store);
+
+  const formGroup = formFactory();
+
+  const persistForm = new PersistNgFormPlugin(query, 'config.form').setForm(formGroup);
+
+  it('should persist only present in the form value properties', () => {
+    const patch = {
+      name: 'Ivan',
+      isAdmin: true
+    };
+
+    formGroup.patchValue(patch);
+    jest.runAllTimers();
+
+    expect(query.getValue().config.form.name).toEqual('Ivan');
+    expect(query.getValue().config.form.isAdmin).toEqual(true);
+    expect(query.getValue().config.form.type).not.toBeUndefined();
+    expect(query.getValue().config.form.type).toEqual('type');
+  });
+});
+
 describe('PersistForm - root key', () => {
   @StoreConfig({ name: 'stories' })
   class StoriesStore extends EntityStore<any, any> {

--- a/akita/src/setValueByString.ts
+++ b/akita/src/setValueByString.ts
@@ -1,3 +1,5 @@
+import { isObject } from './isObject';
+
 /**
  * @internal
  *
@@ -18,7 +20,11 @@ export function setValue(obj: any, prop: string, val: any) {
 
   removeStoreName.reduce((acc, part, index) => {
     if (index === lastIndex) {
-      acc[part] = val;
+      if (isObject(acc[part])) {
+        acc[part] = { ...acc[part], ...val };
+      } else {
+        acc[part] = val;
+      }
     } else {
       acc[part] = { ...acc[part] };
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The PersistNgFormPlugin links the state and form together and updates the state using the value from the valueChanges event. That event emits the value excluding disabled control's values. Everything works fine for the flat state, but if I use tree state and set factoryFnOrPath parameter as 'stepTwo.form' then related state branch will be completely overridden using value excluding values from disabled controls. So the state's shape is changed.

Issue Number: N/A

## What is the new behavior?
PersistNgFormPlugin merges the state, so it doesn't change the state's shape.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
[StackBlitz example](https://stackblitz.com/edit/akita-persist-form-error?file=src%2Fapp%2Fstep-two%2Fstep-two.component.ts)