### PR TITLE
fix(persist-state): localStorage security errors

### DIFF
--- a/akita/src/persistState.ts
+++ b/akita/src/persistState.ts
@@ -10,7 +10,7 @@ import { setValue } from './setValueByString';
 import { $$addStore, $$deleteStore } from './dispatchers';
 import { isNil } from './isNil';
 import { isObject } from './isObject';
-import { isNotBrowser } from './root';
+import { isNotBrowser, hasLocalStorage, hasSessionStorage } from './root';
 
 let skipStorageUpdate = false;
 
@@ -84,7 +84,7 @@ export function persistState(params?: Partial<PersistStateParams>) {
   const defaults: PersistStateParams = {
     key: 'AkitaStores',
     enableInNonBrowser: false,
-    storage: typeof localStorage === 'undefined' ? params.storage : localStorage,
+    storage: !hasLocalStorage() ? params.storage : localStorage,
     deserialize: JSON.parse,
     serialize: JSON.stringify,
     include: [],
@@ -148,7 +148,7 @@ export function persistState(params?: Partial<PersistStateParams>) {
   }
 
   // when we use the local/session storage we perform the serialize, otherwise we let the passed storage implementation to do it
-  const isLocalStorage = typeof localStorage !== 'undefined' && (storage === localStorage || storage === sessionStorage);
+  const isLocalStorage = (hasLocalStorage() && storage === localStorage) || (hasSessionStorage() && storage === sessionStorage);
 
   observify(storage.getItem(key)).subscribe((value: any) => {
     let storageState = isObject(value) ? value : deserialize(value || '{}');

--- a/akita/src/root.ts
+++ b/akita/src/root.ts
@@ -4,14 +4,14 @@ export const isNativeScript = typeof global !== 'undefined' && (<any>global).__r
 export const hasLocalStorage = () => {
   try {
     return typeof localStorage !== 'undefined';
-  } catch (error) {
+  } catch {
     return false;
   }
 }
 export const hasSessionStorage = () => {
   try {
     return typeof sessionStorage !== 'undefined';
-  } catch (error) {
+  } catch {
     return false;
   }
 }

--- a/akita/src/root.ts
+++ b/akita/src/root.ts
@@ -10,7 +10,7 @@ export const hasLocalStorage = () => {
 }
 export const hasSessionStorage = () => {
   try {
-    return typeof localStorage !== 'undefined';
+    return typeof sessionStorage !== 'undefined';
   } catch (error) {
     return false;
   }

--- a/akita/src/root.ts
+++ b/akita/src/root.ts
@@ -1,3 +1,17 @@
 export const isBrowser = typeof window !== 'undefined';
 export const isNotBrowser = !isBrowser;
 export const isNativeScript = typeof global !== 'undefined' && (<any>global).__runtimeVersion !== 'undefined';
+export const hasLocalStorage = () => {
+  try {
+    return typeof localStorage !== 'undefined';
+  } catch (error) {
+    return false;
+  }
+}
+export const hasSessionStorage = () => {
+  try {
+    return typeof localStorage !== 'undefined';
+  } catch (error) {
+    return false;
+  }
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Receiving security errors in multiple browsers when some users goes into incognito mode or have cookies and site data blocked.

For example:
Chrome Mobile: ```SecurityError: Failed to read the 'localStorage' property from 'Window': Access is denied for this document.```
Mobile Safari: ```SecurityError: The operation is insecure.```

You can see the error yourself in Chrome by blocking cookie and site data: https://www.chromium.org/for-testers/bug-reporting-guidelines/uncaught-securityerror-failed-to-read-the-localstorage-property-from-window-access-is-denied-for-this-document

## What is the new behavior?

Wrapping localStorage in a try/catch block is the only way to prevent the error.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
