### PR TITLE
fix(persist-state): ignore storage if not defined

### DIFF
--- a/akita/src/persistState.ts
+++ b/akita/src/persistState.ts
@@ -109,7 +109,7 @@ export function persistState(params?: Partial<PersistStateParams>) {
     params
   );
 
-  if (isNotBrowser && !enableInNonBrowser) return;
+  if ((isNotBrowser && !enableInNonBrowser) || !storage) return;
 
   const hasInclude = include.length > 0;
   const hasExclude = exclude.length > 0;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
This is a continuation of PR https://github.com/datorama/akita/pull/384

If no custom storage is provided to the ```persistState()``` function and the users browser does not allow localStorage then error ```Cannot read property 'getItem' of null``` is thrown.

## What is the new behavior?
Don't make calls to storage if it  is not defined.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
