### PR TITLE
feat(array-utils): added index param on ItemPredicate

### DIFF
--- a/akita/__tests__/arrayRemove.spec.ts
+++ b/akita/__tests__/arrayRemove.spec.ts
@@ -99,4 +99,43 @@ describe('arrayRemove', () => {
 
     expect(store._value().names).toEqual([]);
   });
+
+  it('should remove by index', () => {
+    const article: Article = {
+      id: 1,
+      title: '',
+      comments: [{ id: 1, text: '' }, { id: 2, text: '' }]
+    };
+
+    store.add(article);
+    store.update(1, state => ({
+      comments: arrayRemove(state.comments, (_, index) => index === 0)
+    }));
+
+    const storeValue = store._value().entities[1];
+    expect(storeValue.comments.length).toBe(1);
+    expect(storeValue.comments[1]).toBeUndefined();
+    expect(storeValue.comments[0].id).toBe(2);
+    store.remove();
+  });
+
+  it('should remove by indexes', () => {
+    const article: Article = {
+      id: 1,
+      title: '',
+      comments: [{ id: 1, text: '' }, { id: 2, text: '' }, { id: 3, text: '' }]
+    };
+
+    store.add(article);
+    store.update(1, state => ({
+      comments: arrayRemove(state.comments, (_, index) => [0, 1].includes(index))
+    }));
+
+    const storeValue = store._value().entities[1];
+    expect(storeValue.comments.length).toBe(1);
+    expect(storeValue.comments[1]).toBeUndefined();
+    expect(storeValue.comments[2]).toBeUndefined();
+    expect(storeValue.comments[0].id).toBe(3);
+    store.remove();
+  });
 });

--- a/akita/src/types.ts
+++ b/akita/src/types.ts
@@ -45,7 +45,7 @@ export type StoreCache = {
   ttl: number;
 };
 export type ArrayProperties<T> = { [K in keyof T]: T[K] extends any[] ? K : never }[keyof T];
-export type ItemPredicate<Item = any> = (item: Item) => boolean;
+export type ItemPredicate<Item = any> = (item: Item, index: number) => boolean;
 export type MaybeAsync<T = any> = Promise<T> | Observable<T> | T;
 export type EntityUICreateFn<EntityUI = any, Entity = any> = EntityUI | ((entity: Entity) => EntityUI);
 export type Constructor<T = any> = new (...args: any[]) => T;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

I cannot removing an item of collection by index in easy way, i developed a way to do that by my own:
```
propertyArrayRemoveByIndex(prop: string, index: number): void {
	let iterable = -1;
	this.store.update(state => ({
		[prop]: arrayRemove(state[prop], () => {
			iterable++;
			if (iterable === index) {
				return true;
			}
		})
	}));
}
```

but in your code i found a way to make easier that process

## What is the new behavior?

Basically you can remove an item or items of a collection using an index or indexes as a reference, like Array.prototype.splice if you pass the index as a start point and removing only 1 element (eg.: ['a', 'b', 'c'].splice(1, 1) // returns ['a', 'c'])

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
