### PR TITLE
feat(router): Fire navigation action on completion

### DIFF
--- a/libs/akita-ng-router-store/src/lib/router.service.ts
+++ b/libs/akita-ng-router-store/src/lib/router.service.ts
@@ -5,7 +5,7 @@ import { RouterQuery } from './router.query';
 import { action, setSkipAction } from '@datorama/akita';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class RouterService {
   private dispatchTriggeredByRouter = false;
@@ -38,10 +38,10 @@ export class RouterService {
 
   private update(routerState: Partial<RouterState>) {
     this.dispatchTriggeredByRouter = true;
-    this.routerStore.update(state => {
+    this.routerStore.update((state) => {
       return {
         ...state,
-        ...routerState
+        ...routerState,
       };
     });
     this.dispatchTriggeredByRouter = false;
@@ -50,8 +50,8 @@ export class RouterService {
 
   private setUpStoreListener(): void {
     this.routerQuery
-      .select(state => state)
-      .subscribe(s => {
+      .select((state) => state)
+      .subscribe((s) => {
         this.lastRouterState = s;
         this.navigateIfNeeded();
       });
@@ -70,7 +70,7 @@ export class RouterService {
   }
 
   private setUpStateRollbackEvents(): void {
-    this.router.events.subscribe(e => {
+    this.router.events.subscribe((e) => {
       if (e instanceof RoutesRecognized || e instanceof GuardsCheckEnd || e instanceof ResolveEnd) {
         this.lastRouterState = this.serializeRoute(e);
       } else if (e instanceof NavigationCancel) {
@@ -83,7 +83,7 @@ export class RouterService {
     });
   }
 
-  private serializeRoute(navigationEvent: ResolveEnd | GuardsCheckEnd | ResolveEnd): RouterState {
+  private serializeRoute(navigationEvent: RoutesRecognized | GuardsCheckEnd | ResolveEnd): RouterState {
     let state: ActivatedRouteSnapshot = navigationEvent.state.root;
     while (state.firstChild) {
       state = state.firstChild;
@@ -99,8 +99,8 @@ export class RouterService {
         queryParams,
         fragment,
         data,
-        navigationExtras: this.router.getCurrentNavigation().extras.state
-      }
+        navigationExtras: this.router.getCurrentNavigation().extras.state,
+      },
     };
   }
 }

--- a/libs/akita-ng-router-store/src/lib/router.service.ts
+++ b/libs/akita-ng-router-store/src/lib/router.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
-import { ActivatedRouteSnapshot, NavigationCancel, NavigationError, ResolveEnd, Router, RoutesRecognized } from '@angular/router';
-import { ActiveRouteState, RouterStore } from './router.store';
+import { ActivatedRouteSnapshot, GuardsCheckEnd, NavigationCancel, NavigationEnd, NavigationError, ResolveEnd, Router, RoutesRecognized } from '@angular/router';
+import { RouterState, RouterStore } from './router.store';
 import { RouterQuery } from './router.query';
 import { action, setSkipAction } from '@datorama/akita';
 
@@ -8,29 +8,27 @@ import { action, setSkipAction } from '@datorama/akita';
   providedIn: 'root'
 })
 export class RouterService {
-  private routerStateSnapshot: any;
-  private lastRoutesRecognized: any;
   private dispatchTriggeredByRouter = false;
   private navigationTriggeredByDispatch = false;
-  private routerState: any;
+  private lastRouterState: RouterState;
 
   constructor(private routerStore: RouterStore, private routerQuery: RouterQuery, private router: Router) {}
 
   @action('Navigation Cancelled')
   dispatchRouterCancel(event: NavigationCancel) {
-    this.update();
+    this.update({ navigationId: event.id });
     this.routerQuery.__navigationCancel.next(event);
   }
 
   @action('Navigation Error')
   dispatchRouterError(event: NavigationError) {
-    this.update();
+    this.update({ navigationId: event.id });
     this.routerQuery.__navigationError.next(event);
   }
 
-  @action('Navigation')
-  dispatchRouterNavigation() {
-    this.update();
+  @action('Navigation Succeeded')
+  dispatchRouterSuccess() {
+    this.update(this.lastRouterState);
   }
 
   init() {
@@ -38,13 +36,12 @@ export class RouterService {
     this.setUpStateRollbackEvents();
   }
 
-  private update() {
+  private update(routerState: Partial<RouterState>) {
     this.dispatchTriggeredByRouter = true;
-    this.routerStore.update((state: any) => {
+    this.routerStore.update(state => {
       return {
         ...state,
-        state: this.routerStateSnapshot,
-        navigationId: this.lastRoutesRecognized ? this.lastRoutesRecognized.id : null
+        ...routerState
       };
     });
     this.dispatchTriggeredByRouter = false;
@@ -55,69 +52,55 @@ export class RouterService {
     this.routerQuery
       .select(state => state)
       .subscribe(s => {
-        this.routerState = s;
+        this.lastRouterState = s;
         this.navigateIfNeeded();
       });
   }
 
-  private shouldDispatchRouterNavigation(): boolean {
-    if (!this.routerState) return true;
-    return !this.navigationTriggeredByDispatch;
-  }
-
   private navigateIfNeeded(): void {
-    if (!this.routerState || !this.routerState.state) {
+    if (!this.lastRouterState || !this.lastRouterState.state || this.dispatchTriggeredByRouter) {
       return;
     }
-    if (this.dispatchTriggeredByRouter) return;
 
-    if (this.router.url !== this.routerState.state.url) {
+    if (this.router.url !== this.lastRouterState.state.url) {
       this.navigationTriggeredByDispatch = true;
       setSkipAction();
-      this.router.navigateByUrl(this.routerState.state.url);
+      this.router.navigateByUrl(this.lastRouterState.state.url);
     }
   }
 
   private setUpStateRollbackEvents(): void {
     this.router.events.subscribe(e => {
-      if (e instanceof RoutesRecognized) {
-        this.lastRoutesRecognized = e;
-      } else if (e instanceof ResolveEnd) {
-        this.resolveEnd(e);
+      if (e instanceof RoutesRecognized || e instanceof GuardsCheckEnd || e instanceof ResolveEnd) {
+        this.lastRouterState = this.serializeRoute(e);
       } else if (e instanceof NavigationCancel) {
         this.dispatchRouterCancel(e);
       } else if (e instanceof NavigationError) {
         this.dispatchRouterError(e);
+      } else if (e instanceof NavigationEnd && !this.navigationTriggeredByDispatch) {
+        this.dispatchRouterSuccess();
       }
     });
   }
 
-  /**
-   * The `ResolveEnd` event is always triggered after running all resolvers
-   * that are linked to some route and child routes
-   */
-  private resolveEnd(routerStateSnapshot: ResolveEnd): void {
-    this.routerStateSnapshot = this.serializeRoute(routerStateSnapshot);
-    if (this.shouldDispatchRouterNavigation()) {
-      this.dispatchRouterNavigation();
-    }
-  }
-
-  private serializeRoute(route: ResolveEnd): ActiveRouteState {
-    let state: ActivatedRouteSnapshot = route.state.root;
+  private serializeRoute(navigationEvent: ResolveEnd | GuardsCheckEnd | ResolveEnd): RouterState {
+    let state: ActivatedRouteSnapshot = navigationEvent.state.root;
     while (state.firstChild) {
       state = state.firstChild;
     }
     const { params, data, queryParams, fragment } = state;
 
     return {
-      url: route.url,
-      urlAfterRedirects: route.urlAfterRedirects,
-      params,
-      queryParams,
-      fragment,
-      data,
-      navigationExtras: this.router.getCurrentNavigation().extras.state
+      navigationId: navigationEvent.id,
+      state: {
+        url: navigationEvent.url,
+        urlAfterRedirects: navigationEvent.urlAfterRedirects,
+        params,
+        queryParams,
+        fragment,
+        data,
+        navigationExtras: this.router.getCurrentNavigation().extras.state
+      }
     };
   }
 }

--- a/libs/akita-ng-router-store/src/lib/router.spec.ts
+++ b/libs/akita-ng-router-store/src/lib/router.spec.ts
@@ -1,0 +1,130 @@
+import { APP_BASE_HREF } from '@angular/common';
+import { Component, Injectable, NgZone } from '@angular/core';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, CanActivate, Router, Routes } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { AkitaNgRouterStoreModule } from '..';
+import { RouterQuery } from './router.query';
+import { RouterStore } from './router.store';
+
+@Component({
+  selector: 'test-empty',
+  template: '',
+})
+class EmptyComponent {}
+
+const intentionalTestError = new Error('Intentional test error.');
+
+@Injectable()
+class AuthGuard implements CanActivate {
+  constructor(private router: Router) {}
+
+  canActivate(route: ActivatedRouteSnapshot) {
+    if (route.url.toString().includes('throw-error')) {
+      throw intentionalTestError;
+    }
+
+    if (route.url.toString().includes('redirect-home')) {
+      return this.router.parseUrl('/home');
+    }
+
+    return !route.url.toString().includes('fail-auth-guard');
+  }
+}
+
+const routes: Routes = [
+  {
+    path: 'test/:someParam/:other',
+    component: EmptyComponent,
+  },
+  {
+    path: '**',
+    canActivate: [AuthGuard],
+    component: EmptyComponent,
+  },
+];
+
+describe('RouterService', () => {
+  let routerQuery: RouterQuery;
+  let routerStore: RouterStore;
+  let ngZone: NgZone;
+  let router: Router;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule.withRoutes(routes), AkitaNgRouterStoreModule],
+      declarations: [EmptyComponent],
+      providers: [AuthGuard, { provide: APP_BASE_HREF, useValue: '/' }],
+    }).compileComponents();
+
+    routerQuery = TestBed.inject(RouterQuery);
+    routerStore = TestBed.inject(RouterStore);
+    ngZone = TestBed.inject(NgZone);
+    router = TestBed.inject(Router);
+
+    navigateByUrl('start');
+  });
+
+  function navigateByUrl(url: string) {
+    return ngZone.run(() => router.navigateByUrl(url));
+  }
+
+  it('should update the router state when only query parameters change', async () => {
+    await navigateByUrl('/start?one=1&two=2');
+
+    expect(routerStore._value().navigationId).toEqual(2);
+    expect(routerQuery.getQueryParams()).toEqual({ one: '1', two: '2' });
+  });
+
+  it('should emit a navigationCancel event when canActivate returns false', async () => {
+    expect.assertions(3);
+    routerQuery.selectNavigationCancel().subscribe((event) => {
+      expect(event).toEqual({ id: 2, reason: '', url: '/fail-auth-guard' });
+    });
+
+    await navigateByUrl('fail-auth-guard');
+
+    expect(routerStore._value().navigationId).toEqual(2);
+    expect(routerStore._value().state.url).toEqual('/start');
+  });
+
+  it('should emit a navigationError event when canActivate throws an error', async () => {
+    expect.assertions(3);
+    routerQuery.selectNavigationError().subscribe((event) => {
+      expect(event).toEqual({ id: 2, error: intentionalTestError, url: '/throw-error' });
+    });
+
+    try {
+      await navigateByUrl('throw-error');
+    } catch {}
+
+    expect(routerStore._value().navigationId).toEqual(2);
+    expect(routerStore._value().state.url).toEqual('/start');
+  });
+
+  it('should not update the state with urls that are never activated due to canActivate redirects', fakeAsync(() => {
+    expect.assertions(3);
+
+    routerQuery.selectNavigationCancel().subscribe((event) => {
+      expect(event).toEqual({ id: 2, reason: 'NavigationCancelingError: Redirecting to "/home"', url: '/redirect-home' });
+    });
+
+    routerQuery.select().subscribe(({ navigationId, state }) => {
+      if (navigationId === 2) {
+        expect(state).toEqual({ data: {}, fragment: null, navigationExtras: undefined, params: {}, queryParams: {}, url: '/start', urlAfterRedirects: '/start' });
+      } else if (navigationId === 3) {
+        expect(state).toEqual({ data: {}, fragment: null, navigationExtras: undefined, params: {}, queryParams: {}, url: '/home', urlAfterRedirects: '/home' });
+      }
+    });
+
+    navigateByUrl('/redirect-home');
+    tick();
+  }));
+
+  it('should support selecting route params by name', async () => {
+    await navigateByUrl('/test/100/200');
+
+    expect(routerQuery.getParams('someParam')).toEqual('100');
+    expect(routerQuery.getParams('other')).toEqual('200');
+  });
+});


### PR DESCRIPTION
Fixes the router store not being updated on navigations that don't trigger resolvers.

Closes #398

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 398

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
I investigated pulling in the current version of ngxs router but this approach was simpler.

I tested that this works properly for my use case. Would you like me to set up unit tests for akita-ng-router-store as part of this PR?