### PR TITLE
feature(cacheable): change return type

### DIFF
--- a/libs/akita/src/lib/cacheable.ts
+++ b/libs/akita/src/lib/cacheable.ts
@@ -17,7 +17,7 @@ import { Store } from './store';
  *   }
  * }
  */
-export function cacheable<T>(store: Store, request$: Observable<T>, options: { emitNext: boolean } = { emitNext: false }) {
+export function cacheable<T>(store: Store, request$: Observable<T>, options: { emitNext: boolean } = { emitNext: false }): Observable<T | undefined | never> {
   if (store._cache().value) {
     return options.emitNext ? of(undefined) : EMPTY;
   }


### PR DESCRIPTION
return an actual type from 'cacheable' instead of 'Observable<any>'

fix #407

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #407 

## What is the new behavior?

Now the return type is defined correctly.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
