### PR TITLE
fix(devtools): fix multiple logging of same actions

### DIFF
--- a/libs/akita/src/__tests__/devtools.spec.ts
+++ b/libs/akita/src/__tests__/devtools.spec.ts
@@ -1,0 +1,208 @@
+import { logAction } from '../lib/actions';
+import { capitalize } from '../lib/capitalize';
+import { akitaDevtools } from '../lib/devtools';
+import { Store } from '../lib/store';
+import { applyTransaction } from '../lib/transaction';
+import { TodosStore } from './setup';
+
+function buildActionTypeString(store: Store<any>, type: string) {
+  return `[${capitalize(store.storeName)}] - ${type}`;
+}
+
+describe('DevTools', () => {
+  let store: TodosStore;
+  let connectMock: {
+    subscribe: jest.Mock;
+    init: jest.Mock;
+    send: jest.Mock<void, [string | { type: string }, any]>;
+  };
+
+  beforeAll(() => {
+    // Mock Redux DevTools
+    (window as any).__REDUX_DEVTOOLS_EXTENSION__ = {
+      connect: jest.fn().mockReturnValueOnce(
+        (connectMock = {
+          subscribe: jest.fn(),
+          init: jest.fn(),
+          send: jest.fn(),
+        })
+      ),
+    };
+
+    // Enable DevTools
+    akitaDevtools();
+  });
+
+  beforeEach(() => {
+    store = new TodosStore();
+  });
+
+  it(`should log action: Store initialized`, () => {
+    expect(connectMock.send.mock.calls.length).toBe(1);
+    expect(connectMock.send.mock.calls[0][0]['type']).toBe(buildActionTypeString(store, `@@INIT`));
+  });
+
+  it(`should log action: Update store state`, () => {
+    connectMock.send.mockReset();
+    store.update({ metadata: { name: 'foo' } });
+
+    expect(connectMock.send.mock.calls.length).toBe(1);
+    expect(connectMock.send.mock.calls[0][0]['type']).toBe(buildActionTypeString(store, `Update`));
+  });
+
+  it(`should log action: Set Entities`, () => {
+    connectMock.send.mockReset();
+    store.set([{ id: 1 }, { id: 2 }]);
+
+    expect(connectMock.send.mock.calls.length).toBe(1);
+    expect(connectMock.send.mock.calls[0][0]['type']).toBe(buildActionTypeString(store, `Set Entity`));
+  });
+
+  it(`should log action: Add Entities`, () => {
+    connectMock.send.mockReset();
+    store.add([{ id: 1 }, { id: 2 }]);
+
+    expect(connectMock.send.mock.calls[0][0]['type']).toBe(buildActionTypeString(store, `Add Entity`));
+    expect(connectMock.send.mock.calls[0][1]['todos']['entities']).toEqual(
+      expect.objectContaining({
+        1: { id: 1 },
+        2: { id: 2 },
+      })
+    );
+  });
+
+  it(`should log action: Remove Entities`, () => {
+    store.add([{ id: 1 }, { id: 2 }]);
+    connectMock.send.mockReset();
+    store.remove([1, 2]);
+
+    expect(connectMock.send.mock.calls.length).toBe(1);
+    expect(connectMock.send.mock.calls[0][0]['type']).toEqual(expect.stringContaining(buildActionTypeString(store, `Remove Entity`)));
+    expect(connectMock.send.mock.calls[0][1]['todos']['entities']).toEqual(
+      expect.not.objectContaining({
+        1: { id: 1 },
+        2: { id: 2 },
+      })
+    );
+  });
+
+  it(`should log action: Update Entities`, () => {
+    store.add([{ id: 1 }, { id: 2 }]);
+    connectMock.send.mockReset();
+    store.update(1, { title: 'title' });
+
+    expect(connectMock.send.mock.calls.length).toBe(1);
+    expect(connectMock.send.mock.calls[0][0]['type']).toEqual(expect.stringContaining(buildActionTypeString(store, `Update Entity`)));
+    expect(connectMock.send.mock.calls[0][1]['todos']['entities']).toEqual(
+      expect.objectContaining({
+        1: { id: 1, title: 'title' },
+        2: { id: 2 },
+      })
+    );
+  });
+
+  it(`should log action: Upsert Entities`, () => {
+    connectMock.send.mockReset();
+    store.upsert(1, { title: 'title' });
+
+    expect(connectMock.send.mock.calls.length).toBe(1);
+    expect(connectMock.send.mock.calls[0][0]['type']).toEqual(expect.stringContaining(buildActionTypeString(store, `Upsert Entity`)));
+    expect(connectMock.send.mock.calls[0][1]['todos']['entities']).toEqual(
+      expect.objectContaining({
+        1: { id: 1, title: 'title' },
+      })
+    );
+  });
+
+  it(`should log action: Upsert Many Entities`, () => {
+    store.add([{ id: 1 }]);
+    connectMock.send.mockReset();
+    store.upsertMany([
+      { id: 1, title: 'title' },
+      { id: 2, title: 'title' },
+    ]);
+
+    expect(connectMock.send.mock.calls.length).toBe(1);
+    expect(connectMock.send.mock.calls[0][0]['type']).toEqual(expect.stringContaining(buildActionTypeString(store, `Upsert Many`)));
+    expect(connectMock.send.mock.calls[0][1]['todos']['entities']).toEqual(
+      expect.objectContaining({
+        1: { id: 1, title: 'title' },
+        2: { id: 2, title: 'title' },
+      })
+    );
+  });
+
+  it(`should log action in correct order`, () => {
+    store.add([{ id: 1 }, { id: 2 }]);
+    connectMock.send.mockReset();
+    store.update(1, { title: 'title' });
+    store.remove(2);
+
+    expect(connectMock.send.mock.calls.length).toBe(2);
+
+    expect(connectMock.send.mock.calls[0][0]['type']).toEqual(expect.stringContaining(buildActionTypeString(store, `Update Entity`)));
+    expect(connectMock.send.mock.calls[0][1]['todos']['entities']).toEqual(
+      expect.objectContaining({
+        1: { id: 1, title: 'title' },
+      })
+    );
+
+    expect(connectMock.send.mock.calls[1][0]['type']).toEqual(expect.stringContaining(buildActionTypeString(store, `Remove Entity`)));
+    expect(connectMock.send.mock.calls[1][1]['todos']['entities']).toEqual(
+      expect.not.objectContaining({
+        1: { id: 2 },
+      })
+    );
+  });
+
+  it(`should only log action of a transaction`, () => {
+    store.add([{ id: 1 }, { id: 2 }]);
+    connectMock.send.mockReset();
+
+    applyTransaction(() => {
+      store.update(1, { title: 'title' });
+      store.remove(2);
+    });
+
+    expect(connectMock.send.mock.calls.length).toBe(1);
+    expect(connectMock.send.mock.calls[0][0]['type']).toEqual(expect.stringContaining(buildActionTypeString(store, `@Transaction`)));
+  });
+
+  it(`should only log custom action of a transaction`, () => {
+    store.add([{ id: 1 }, { id: 2 }]);
+    connectMock.send.mockReset();
+
+    logAction('Custom Action');
+    applyTransaction(() => {
+      store.update(1, { title: 'title' });
+      store.remove(2);
+    });
+
+    expect(connectMock.send.mock.calls.length).toBe(1);
+    expect(connectMock.send.mock.calls[0][0]['type']).toEqual(expect.stringContaining(buildActionTypeString(store, `Custom Action`)));
+  });
+
+  it(`should only log outmost custom action of nested transactions`, () => {
+    store.add([{ id: 1 }, { id: 2 }]);
+    connectMock.send.mockReset();
+
+    logAction('Custom Action');
+    applyTransaction(() => {
+      store.update(1, { title: 'title' });
+      logAction('Custom Action 2');
+      applyTransaction(() => {
+        store.update(1, { title: 'title 2' });
+        store.remove(2);
+      });
+      store.remove(1);
+    });
+
+    expect(connectMock.send.mock.calls.length).toBe(1);
+    expect(connectMock.send.mock.calls[0][0]['type']).toEqual(expect.stringContaining(buildActionTypeString(store, `Custom Action`)));
+  });
+
+  afterEach(() => {
+    store.destroy();
+    connectMock.send.mockReset();
+  });
+});

--- a/libs/akita/src/__tests__/setup.ts
+++ b/libs/akita/src/__tests__/setup.ts
@@ -22,11 +22,11 @@ export interface State extends EntityState<Todo>, ActiveState {
 
 export const initialState: State = {
   active: null,
-  metadata: { name: 'metadata' }
+  metadata: { name: 'metadata' },
 };
 
 @StoreConfig({
-  name: 'todos'
+  name: 'todos',
 })
 export class TodosStore extends EntityStore<State, Todo> {
   constructor(options?) {
@@ -44,11 +44,11 @@ export interface StateTwo extends EntityState<TodoCustomID> {}
 
 @StoreConfig({
   name: 'todos',
-  idKey: 'todoId'
+  idKey: 'todoId',
 })
 export class TodosStoreCustomID extends EntityStore<StateTwo, TodoCustomID> {
   constructor() {
-    super(initialState, { idKey: 'todoId' });
+    super({}, { idKey: 'todoId' });
   }
 }
 
@@ -63,12 +63,12 @@ export function createTodos(len) {
 
 export function ct() {
   let count = 0;
-  return function() {
+  return function () {
     const id = count++;
     return {
       id,
       title: `Todo ${id}`,
-      complete: false
+      complete: false,
     } as Todo;
   };
 }
@@ -77,7 +77,7 @@ export function cot() {
   return {
     id: 1,
     title: `Todo ${1}`,
-    complete: false
+    complete: false,
   } as Todo;
 }
 
@@ -104,7 +104,7 @@ export function createWidget(id) {
   return {
     id,
     title: `Widget ${id}`,
-    complete: false
+    complete: false,
   } as Widget;
 }
 

--- a/libs/akita/src/lib/actions.ts
+++ b/libs/akita/src/lib/actions.ts
@@ -1,7 +1,15 @@
-export const currentAction = {
+import { IDS } from './types';
+
+export interface StoreSnapshotAction {
+  type: string | null;
+  entityIds: IDS[] | null;
+  skip: boolean;
+}
+
+export const currentAction: StoreSnapshotAction = {
   type: null,
   entityIds: null,
-  skip: false
+  skip: false,
 };
 
 let customActionActive = false;
@@ -28,9 +36,9 @@ export function setSkipAction(skip = true) {
 }
 
 export function action(action: string, entityIds?) {
-  return function(target: any, propertyKey: string, descriptor: PropertyDescriptor) {
+  return function (target: any, propertyKey: string, descriptor: PropertyDescriptor) {
     const originalMethod = descriptor.value;
-    descriptor.value = function(...args) {
+    descriptor.value = function (...args) {
       logAction(action, entityIds);
       return originalMethod.apply(this, args);
     };

--- a/libs/akita/src/lib/devtools.ts
+++ b/libs/akita/src/lib/devtools.ts
@@ -84,9 +84,9 @@ export function akitaDevtools(ngZoneOrOptions?: NgZoneLike | Partial<DevtoolsOpt
   );
 
   subs.push(
-    $$updateStore.subscribe((storeName) => {
+    $$updateStore.subscribe(({ storeName, action }) => {
       if (isAllowed(storeName) === false) return;
-      const { type, entityIds, skip } = currentAction;
+      const { type, entityIds, skip } = action;
 
       if (skip) {
         setSkipAction(false);

--- a/libs/akita/src/lib/dispatchers.ts
+++ b/libs/akita/src/lib/dispatchers.ts
@@ -1,11 +1,12 @@
 import { ReplaySubject, Subject } from 'rxjs';
+import { StoreSnapshotAction } from './store';
 
 // @internal
 export const $$deleteStore = new Subject<string>();
 // @internal
 export const $$addStore = new ReplaySubject<string>(50, 5000);
 // @internal
-export const $$updateStore = new Subject<string>();
+export const $$updateStore = new Subject<{ storeName: string; action: StoreSnapshotAction }>();
 
 // @internal
 export function dispatchDeleted(storeName: string) {
@@ -18,6 +19,6 @@ export function dispatchAdded(storeName: string) {
 }
 
 // @internal
-export function dispatchUpdate(storeName: string) {
-  $$updateStore.next(storeName);
+export function dispatchUpdate(storeName: string, action: StoreSnapshotAction) {
+  $$updateStore.next({ storeName, action });
 }

--- a/libs/akita/src/lib/dispatchers.ts
+++ b/libs/akita/src/lib/dispatchers.ts
@@ -1,5 +1,5 @@
 import { ReplaySubject, Subject } from 'rxjs';
-import { StoreSnapshotAction } from './store';
+import { StoreSnapshotAction } from './actions';
 
 // @internal
 export const $$deleteStore = new Subject<string>();

--- a/libs/akita/src/lib/store.ts
+++ b/libs/akita/src/lib/store.ts
@@ -185,11 +185,15 @@ export class Store<S = any> {
 
     if (!this.store) {
       this.store = new BehaviorSubject({ state: this.storeValue });
-      this.store.subscribe(({ action }) => {
-        if (action) {
-          dispatchUpdate(this.storeName, action);
-        }
-      });
+
+      if (isDev()) {
+        this.store.subscribe(({ action }) => {
+          if (action) {
+            dispatchUpdate(this.storeName, action);
+          }
+        });
+      }
+
       return;
     }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

A store update triggers query subscribers before releasing the current log action through `resetCustomAction()`:  So if a query subscriber itself triggers a `logAction()` after a previous one (which is still blocking/holding the log action), the previous will be logged again. This is caused by RxJS which is executing all subscribers synchronously and thus the `resetCustomAction()` is executed after `next()` has finished in `dispatch()` (and therefore after the query subscribers). 

Issue Number: #396

## What is the new behavior?

The store `BehaviourSubject` itself holds beside the current state the associated log action and sends it to the Redux DevTools before query subscribers are called.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

