### PR TITLE
docs: remove line break in GenresQuery

### DIFF
--- a/docs/docs/transactions.mdx
+++ b/docs/docs/transactions.mdx
@@ -102,8 +102,7 @@ export class MoviesQuery extends QueryEntity<MoviesState> {
 
   constructor(protected store: MoviesStore, 
               private actorsQuery: ActorsQuery, 
-              private genresQuery: GenresQ
-uery) {
+              private genresQuery: GenresQuery) {
     super(store);
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

There's a line break in the `GenresQuery` word:

<img width="844" alt="Screenshot 2020-06-18 at 15 12 29" src="https://user-images.githubusercontent.com/17194770/85025714-0a95c200-b178-11ea-8d95-b7037cd44e3a.png">

Issue Number: N/A

## What is the new behavior?

There's no line break in `GenresQuery` anymore.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information