### PR TITLE
fix(akita): added getStoreByName to index.ts

### DIFF
--- a/libs/akita/src/lib/index.ts
+++ b/libs/akita/src/lib/index.ts
@@ -55,7 +55,7 @@ export { SelectAllOptionsA, SelectAllOptionsB, SelectAllOptionsC, SelectAllOptio
 export { __stores__ } from './stores';
 export { isDev, enableAkitaProdMode, __DEV__ } from './env';
 export { isNotBrowser } from './root';
-export { runStoreAction, runEntityStoreAction, getStore, getEntityStore, EntityStoreAction, StoreAction } from './runStoreAction';
+export { runStoreAction, runEntityStoreAction, getStore, getStoreByName, getEntityStore, getEntityStoreByName, EntityStoreAction, StoreAction } from './runStoreAction';
 export { arrayUpdate } from './arrayUpdate';
 export { arrayAdd } from './arrayAdd';
 export { arrayUpsert } from './arrayUpsert';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

you couldn't import the function `getStoreByName` also the `getEntityStoreByName`

Issue Number: N/A

## What is the new behavior?

now you can import the function `getStoreByName` also the `getEntityStoreByName`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
