### PR TITLE
feature(schematics): adding the option the create MultiActive entity store

### DIFF
--- a/libs/akita-schematics/src/ng-g/entity-store/files/__name@dasherize__.store.ts
+++ b/libs/akita-schematics/src/ng-g/entity-store/files/__name@dasherize__.store.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { EntityState<% if (withActive) { %>, ActiveState<%}%>, EntityStore, StoreConfig } from '@datorama/akita';
+import { <%= importsString %> } from '@datorama/akita';
 import { <%= singular(classify(name)) %> } from './<%= singular(dasherize(name)) %>.model';
 
 export interface <%= classify(name) %>State extends <%= extensionState %> {}

--- a/libs/akita-schematics/src/ng-g/entity-store/index.ts
+++ b/libs/akita-schematics/src/ng-g/entity-store/index.ts
@@ -1,8 +1,10 @@
-import { Rule, apply, branchAndMerge, chain, filter, mergeWith, move, noop, template, url, Tree, SchematicContext } from '@angular-devkit/schematics';
+import { apply, branchAndMerge, chain, filter, mergeWith, move, noop, Rule, SchematicContext, template, Tree, url } from '@angular-devkit/schematics';
 
-import { getProjectPath, stringUtils, parseName } from '../utils';
+import { getProjectPath, parseName, stringUtils } from '../utils';
+import { EntityStoreOptions } from './models/entity-store-options.model';
+import { ActiveStateType } from './models/active-state.enum';
 
-function getExtensionState({ idType, name, withActive }: any) {
+function getExtensionState({ idType, name, withActive }: EntityStoreOptions) {
   const isID = idType === 'string' || idType === 'number';
   const entityName = name.split('/').pop();
   const entityType = stringUtils.singular(stringUtils.classify(entityName));
@@ -12,30 +14,41 @@ function getExtensionState({ idType, name, withActive }: any) {
   }
   const extensions = [`EntityState<${generics.join(', ')}>`];
   if (withActive) {
-    const activeState = isID ? `ActiveState<${idType}>` : `ActiveState`;
+    let activeState = withActive === ActiveStateType.Single ? `ActiveState` : `MultiActiveState`;
+    activeState += isID ? `<${idType}>` : ``;
     extensions.push(activeState);
   }
   return extensions.join(', ');
 }
 
-export default function(options: any): Rule {
+function getImportsString({ withActive }: EntityStoreOptions) {
+  const imports = ['EntityState', 'EntityStore', 'StoreConfig'];
+  if (withActive) {
+    imports.push(`${withActive}State`);
+  }
+  return imports.join(', ');
+}
+
+export default function (options: EntityStoreOptions): Rule {
   return (host: Tree, context: SchematicContext) => {
     options.path = getProjectPath(host, options);
 
     // Build state based on options
     const extensionState = getExtensionState(options);
+    const importsString = getImportsString(options);
 
     const parsedPath = parseName(options);
     options.name = parsedPath.name;
     options.path = parsedPath.path;
     const templateSource = apply(url('./files'), [
-      options.spec ? noop() : filter(path => !path.endsWith('.spec.ts')),
+      options.spec ? noop() : filter((path) => !path.endsWith('.spec.ts')),
       template({
         ...stringUtils,
         ...(options as object),
-        extensionState
+        extensionState,
+        importsString,
       } as any),
-      move(parsedPath.path)
+      move(parsedPath.path),
     ]);
 
     return chain([branchAndMerge(chain([mergeWith(templateSource)]))])(host, context);

--- a/libs/akita-schematics/src/ng-g/entity-store/models/active-state.enum.ts
+++ b/libs/akita-schematics/src/ng-g/entity-store/models/active-state.enum.ts
@@ -1,0 +1,4 @@
+export enum ActiveStateType {
+  Single = 'Active',
+  Multi = 'MultiActive',
+}

--- a/libs/akita-schematics/src/ng-g/entity-store/models/entity-store-options.model.ts
+++ b/libs/akita-schematics/src/ng-g/entity-store/models/entity-store-options.model.ts
@@ -1,0 +1,10 @@
+import { ActiveStateType } from './active-state.enum';
+
+export interface EntityStoreOptions {
+  name: string;
+  path: string;
+  spec: boolean;
+  dirName: string;
+  withActive: ActiveStateType;
+  idType: string;
+}

--- a/libs/akita-schematics/src/ng-g/entity-store/schema.json
+++ b/libs/akita-schematics/src/ng-g/entity-store/schema.json
@@ -29,9 +29,9 @@
       "description": "Specifies the name of the generated folder"
     },
     "withActive": {
-      "type": "boolean",
-      "default": false,
-      "description": "Specifies if the entity state is ActiveState"
+      "type": "string",
+      "enum": ["Active", "MultiActive"],
+      "description": "Specifies if the entity state is ActiveState or MultiActiveState"
     },
     "idType": {
       "type": "string",

--- a/libs/akita-schematics/src/ng-g/feature/index.ts
+++ b/libs/akita-schematics/src/ng-g/feature/index.ts
@@ -1,12 +1,13 @@
-import { Rule, SchematicContext, Tree, chain, schematic } from '@angular-devkit/schematics';
+import { chain, Rule, schematic, SchematicContext, Tree } from '@angular-devkit/schematics';
+import { ActiveStateType } from '../entity-store/models/active-state.enum';
 
 const enum EntityServiceType {
   http = 'Http',
   firebase = 'Firebase',
-  default = 'Default'
+  default = 'Default',
 }
 
-export default function(options: any): Rule {
+export default function (options: any): Rule {
   const plain = options.plain;
   const withModule = options.withModule;
   const entityService = plain ? 'default' : options.entityService;
@@ -22,8 +23,8 @@ export default function(options: any): Rule {
       dirName: options.dirName,
       feature: true,
       spec: options.spec,
-      withActive: entityService === EntityServiceType.firebase ? true : options.withActive,
-      idType: entityService === EntityServiceType.firebase ? 'string' : options.idType
+      withActive: entityService === EntityServiceType.firebase ? ActiveStateType.Single : options.withActive,
+      idType: entityService === EntityServiceType.firebase ? 'string' : options.idType,
     }),
     schematic(plain ? 'query' : 'entity-query', {
       flat: options.flat,
@@ -32,7 +33,7 @@ export default function(options: any): Rule {
       project: options.project,
       spec: options.spec,
       dirName: options.dirName,
-      feature: true
+      feature: true,
     }),
     schematic(serviceSchematic, {
       flat: options.flat,
@@ -43,8 +44,8 @@ export default function(options: any): Rule {
       spec: options.spec,
       plain,
       dirName: options.dirName,
-      feature: true
-    })
+      feature: true,
+    }),
   ];
 
   if (!plain) {
@@ -57,8 +58,8 @@ export default function(options: any): Rule {
         project: options.project,
         spec: options.spec,
         dirName: options.dirName,
-        feature: true
-      })
+        feature: true,
+      }),
     ]);
   }
 
@@ -72,7 +73,7 @@ export default function(options: any): Rule {
         project: options.project,
         spec: options.spec,
         dirName: options.dirName,
-        feature: true
+        feature: true,
       }),
 
       schematic('withComponent', {
@@ -85,8 +86,8 @@ export default function(options: any): Rule {
         dirName: options.dirName,
         styleext: options.styleext,
         entity: !options.plain,
-        feature: true
-      })
+        feature: true,
+      }),
     ]);
   }
   return (host: Tree, context: SchematicContext) => {

--- a/libs/akita-schematics/src/ng-g/feature/schema.json
+++ b/libs/akita-schematics/src/ng-g/feature/schema.json
@@ -55,9 +55,9 @@
       "type": "boolean"
     },
     "withActive": {
-      "type": "boolean",
-      "default": false,
-      "description": "Specifies if the entity state is ActiveState"
+      "type": "string",
+      "enum": ["Active", "MultiActive"],
+      "description": "Specifies if the entity state is ActiveState or MultiActiveState"
     },
     "idType": {
       "type": "string",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?


- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
In the current behavior, you can't generate an entity store with MultiActive implementation using Schematics.

Issue Number: [#468](https://github.com/datorama/akita/issues/468)

## What is the new behavior?
From now on you can pass to the flag withActive a value - "Active" | "MultiActive" and it will generate the desired state.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
