### PR TITLE
docs: fix broken array utils link

### DIFF
--- a/docs/docs/best-practices.mdx
+++ b/docs/docs/best-practices.mdx
@@ -59,7 +59,7 @@ class ArticlesStore extends EntityStore<ArticlesState> {
 }
 ```
 
-In most cases, there is no need to create a separate entity store for the `comments`. Instead use Akita's [Array Utils](../additional/array). This will keep your store easier to maintain and use. If you still require a separate store, check out this article for tips on how to combine their data:
+In most cases, there is no need to create a separate entity store for the `comments`. Instead use Akita's [Array Utils](additional/array). This will keep your store easier to maintain and use. If you still require a separate store, check out this article for tips on how to combine their data:
 
 - [Working with Normalized Data in Akita and Angular](https://netbasal.com/working-with-normalized-data-in-akita-e626d4c67ca4)
 - [Introducing One To Many Relationship in Angular & Akita](https://dev.to/arielgueta/introducing-one-to-many-relationship-in-angular-akita-37me)


### PR DESCRIPTION
The Best Practices page had a broken link to the Array Utils page

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

https://datorama.github.io/akita/docs/best-practices has a bad link to the Array Utils page. It is linking to https://datorama.github.io/akita/additional/array instead of https://datorama.github.io/akita/docs/additional/array

Issue Number: N/A

## What is the new behavior?
Fixes the broken link
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
