### PR TITLE
Add disableTracking to StoreConfig

### DIFF
--- a/docs/docs/config.mdx
+++ b/docs/docs/config.mdx
@@ -62,6 +62,10 @@ See [caching support](../additional/cache) section.
 ### `idKey`
 A custom `idKey` for `EntityStore` - see [EntityId](../entities/entity-store#entity-id) section.
 
+### `disableTracking`
+Option to disable devtools tracking.
+
+
 :::info
 You can also provide the `options` in the constructor:
 

--- a/libs/akita/src/__tests__/devtools.spec.ts
+++ b/libs/akita/src/__tests__/devtools.spec.ts
@@ -3,7 +3,7 @@ import { capitalize } from '../lib/capitalize';
 import { akitaDevtools } from '../lib/devtools';
 import { Store } from '../lib/store';
 import { applyTransaction } from '../lib/transaction';
-import { TodosStore } from './setup';
+import { TodosStore, DisabledTrackingConfigStore } from './setup';
 
 function buildActionTypeString(store: Store<any>, type: string) {
   return `[${capitalize(store.storeName)}] - ${type}`;
@@ -199,6 +199,17 @@ describe('DevTools', () => {
 
     expect(connectMock.send.mock.calls.length).toBe(1);
     expect(connectMock.send.mock.calls[0][0]['type']).toEqual(expect.stringContaining(buildActionTypeString(store, `Custom Action`)));
+  });
+
+  it('should log only if disableTracking is not true', function () {
+    connectMock.send.mockReset();
+    const noTrackingStoreConfig = new DisabledTrackingConfigStore();
+    const noTrackingStoreOptions = new Store({}, { disableTracking: true });
+
+    noTrackingStoreConfig.setLoading();
+    noTrackingStoreOptions.setLoading();
+
+    expect(connectMock.send.mock.calls.length).toBe(0);
   });
 
   afterEach(() => {

--- a/libs/akita/src/__tests__/setup.ts
+++ b/libs/akita/src/__tests__/setup.ts
@@ -109,3 +109,6 @@ export function createWidget(id) {
 }
 
 export const tick = () => new Promise(process.nextTick);
+
+@StoreConfig({ name: 'disabledTrackingConfig', disableTracking: true })
+export class DisabledTrackingConfigStore extends EntityStore<State> {}

--- a/libs/akita/src/lib/devtools.ts
+++ b/libs/akita/src/lib/devtools.ts
@@ -57,7 +57,7 @@ export function akitaDevtools(ngZoneOrOptions?: NgZoneLike | Partial<DevtoolsOpt
   let appState = {};
 
   const isAllowed = (storeName) => {
-    if (!storesWhitelist.length) {
+    if (!storesWhitelist.length && !__stores__[storeName].disabledTracking) {
       return true;
     }
 

--- a/libs/akita/src/lib/store.ts
+++ b/libs/akita/src/lib/store.ts
@@ -175,6 +175,11 @@ export class Store<S = any> {
   }
 
   // @internal
+  get disabledTracking() {
+    return isDefined(this.config.disableTracking) ? this.config.disableTracking : this.options.disableTracking;
+  }
+
+  // @internal
   _setState(newState: ((state: Readonly<S>) => S) | S, _dispatchAction = true) {
     if (isFunction(newState)) {
       const _newState = newState(this._value());

--- a/libs/akita/src/lib/storeConfig.ts
+++ b/libs/akita/src/lib/storeConfig.ts
@@ -7,6 +7,7 @@ export type StoreConfigOptions = {
   deepFreezeFn?: (o: any) => any;
   idKey?: string;
   producerFn?: AkitaConfig['producerFn'];
+  disableTracking?: boolean;
 };
 
 export type UpdatableStoreConfigOptions = {
@@ -16,7 +17,7 @@ export type UpdatableStoreConfigOptions = {
 export const configKey = 'akitaConfig';
 
 export function StoreConfig(metadata: StoreConfigOptions) {
-  return function(constructor: Function) {
+  return function (constructor: Function) {
     constructor[configKey] = { idKey: 'id' };
 
     for (let i = 0, keys = Object.keys(metadata); i < keys.length; i++) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently there is no way to exclude certain store from devtools tracking through store config.

Issue Number: N/A

## What is the new behavior?

With new disableTracking flag it is possible to disable tracking for a certain store allowing you to use it in a library and having an option to not pollute applications devtools tracking or providing an option to turn it on when needed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
