### PR TITLE
Update tests.mdx

### DIFF
--- a/docs/docs/angular/tests.mdx
+++ b/docs/docs/angular/tests.mdx
@@ -71,20 +71,14 @@ We can mock the query and in each spec provide the selector result:
 
 describe('TodosPageComponent', () => {
   let component: TodosPageComponent;
-  let todosQuery: jasmine.SpyObj<TodosQuery>;
+  let todosQuery: TodosQuery;
   let fixture: ComponentFixture<TodosPageComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       providers: [
-        {
-          provide: TodosService,
-          useValue: jasmine.createSpyObj('TodosService', ['get'])
-        },
-        {
-          provide: TodosQuery,
-          useValue: jasmine.createSpyObj('TodosQuery', ['selectAll'])
-        }
+        TodosService,
+        TodosQuery
       ],
       declarations: [TodosComponent]
     }).compileComponents();
@@ -143,10 +137,7 @@ describe('TodosPageComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       providers: [
-        {
-          provide: TodosService,
-          useValue: jasmine.createSpyObj('TodosService', ['get'])
-        }
+       TodosService,
       ],
       declarations: [TodosComponent]
     }).compileComponents();
@@ -155,7 +146,7 @@ describe('TodosPageComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(TodosComponent);
     component = fixture.componentInstance;
-    todosStore = TestBed.get(TodosStore);
+    todosStore = TestBed.inject(TodosStore);
   });
 
   it('should display no todos message', () => {


### PR DESCRIPTION
- Since Angular 9.0.0 TestBed.get() is deprecated. Use TestBed.inject() --> https://angular.io/api/core/testing/TestBed#get 
- jasmine.SpyObj<T> will create a type error, if using TestBed.inject() --> Just give the Type

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The Documentations shows deprecated code, which results in errors.

Issue Number: N/A

## What is the new behavior?
With the adjustment, the code can be used for a valuable test. For More information visit: [Angular.io](https://angular.io/api/core/testing/TestBed#get)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
