### PR TITLE
fix(router-store): serializeRoute 'state' undefined

### DIFF
--- a/libs/akita-ng-router-store/src/lib/router.service.ts
+++ b/libs/akita-ng-router-store/src/lib/router.service.ts
@@ -99,7 +99,7 @@ export class RouterService {
         queryParams,
         fragment,
         data,
-        navigationExtras: this.router.getCurrentNavigation().extras.state,
+        navigationExtras: this.router.getCurrentNavigation().extras ? this.router.getCurrentNavigation().extras.state : {},
       },
     };
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
I don't know what provokes `router.getCurrentNavigation().extras` to be undefined.
Trying the obvious by navigating the router with undefined as the extras parameter still doesn't return undefined. `await ngZone.run(() => router.navigate(['/test/undefined'], undefined));`
So unless someone figures out the cause of the issue, I don't think a test makes sense.

- [ ] ~~Docs have been added / updated (for bug fixes / features)~~
I don't think there's anything to document here.


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #399 

## What is the new behavior?
SerializeRouter now returns an empty object for 'navigationExtras' should the `router.getCurrentNavigation().extras.state` be unavailable (undefined) for any reason.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I cannot test the locally compiled library due to some weird rxjs dependency errors. I did test the fix in the transpiled version that is imported into my project.