### PR TITLE
Fix links in config.mdx

### DIFF
--- a/docs/docs/config.mdx
+++ b/docs/docs/config.mdx
@@ -57,10 +57,10 @@ export class SessionStore extends Store<Session> {
 ```
 
 ### `cache`
-See [caching support](../additional/cache) section.
+See [caching support](additional/cache.mdx) section.
 
 ### `idKey`
-A custom `idKey` for `EntityStore` - see [EntityId](../entities/entity-store#entity-id) section.
+A custom `idKey` for `EntityStore` - see [EntityId](entities/entity-store.mdx#entity-id) section.
 
 :::info
 You can also provide the `options` in the constructor:


### PR DESCRIPTION
Fix links to cache and entity id. Add .mdx to file name so the links also work when editing in Github.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A
"Caching Support" and "EntityId" links do not work

## What is the new behavior?
The links now link to the correct pages.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
