### PR TITLE
Feature/entity service sub resources

### DIFF
--- a/docs/docs/angular/entity-service.mdx
+++ b/docs/docs/angular/entity-service.mdx
@@ -22,10 +22,10 @@ ng g af posts
 This schematics command generates an Akita `PostsStore`, `PostsQuery`, and `PostsService`. First we need to define the base api url that will be used for each request. This is done when adding the service configuration to the module:
 
 ```ts title="app.module.ts"
-import { 
-  HttpMethod, 
-  NG_ENTITY_SERVICE_CONFIG, 
-  NgEntityServiceGlobalConfig 
+import {
+  HttpMethod,
+  NG_ENTITY_SERVICE_CONFIG,
+  NgEntityServiceGlobalConfig
 } from '@datorama/akita-ng-entity-service';
 
 @NgModule({
@@ -103,6 +103,7 @@ As you can see, since all the tasks of initalizing the requests and updating the
   params?: HttpParams;
   headers?: HttpHeaders;
   url?: string;
+  urlPostfix?: string;
   mapResponseFn?: (res) => Entity | Entity[];
 }
 ```
@@ -131,8 +132,8 @@ Akita’s Entity Service comes with a built-in solution for these cases; The `Ng
 
 
 ```ts title="posts.component.ts"
-import { 
-  NgEntityServiceLoader 
+import {
+  NgEntityServiceLoader
 } from '@datorama/akita-ng-entity-service';
 
 @Component()
@@ -159,11 +160,11 @@ The `loaders` object now contains loading indicators for each of the `PostsServi
 
 <h5>Loaders</h5>
 
-<p>Get => 
+<p>Get =>
   <span *ngIf="(loaders.get$ | async); else idle">Loading...</span>
 </p>
 
-<p>POST => 
+<p>POST =>
   <span *ngIf="(loaders.add$ | async); else idle">Loading...</span>
 </p>
 
@@ -171,7 +172,7 @@ The `loaders` object now contains loading indicators for each of the `PostsServi
   span *ngIf="(loaders.update$ | async); else idle">Loading...</span>
 </p>
 
-<p>DELETE => 
+<p>DELETE =>
   <span *ngIf="(loaders.delete$ | async); else idle">Loading...</span>
  </p>
 ```
@@ -184,8 +185,8 @@ In addition to that there are cases when we need to know whether certain operati
 For this purpose the Entity Service package provides the `NgEntityServiceNotifier` service, which we can subscribe to and get the status of any HTTP call that was made:
 
 ```ts title="notification.service.ts"
-import { 
-  NgEntityServiceNotifier 
+import {
+  NgEntityServiceNotifier
 } from '@datorama/akita-ng-entity-service';
 
 class NotificationService {
@@ -217,11 +218,11 @@ The resulting data looks like this:
 The package also exposes built-in operators, which allow us to filter the `type`, `store`, and `HTTP` method. For example:
 
 ```ts
-import { 
+import {
  NgEntityServiceNotifier,
- filterMethod, 
- ofType, 
- filterStore 
+ filterMethod,
+ ofType,
+ filterStore
 } from '@datorama/akita-ng-entity-service';
 
 this.notifier.action$.pipe(

--- a/libs/akita-ng-entity-service/src/lib/ng-entity-service.spec.ts
+++ b/libs/akita-ng-entity-service/src/lib/ng-entity-service.spec.ts
@@ -8,7 +8,7 @@ import {
   TestServiceWithInlineConfig,
   TestServiceWithMixedConfig,
   storeName,
-  TestEntity
+  TestEntity,
 } from './setup';
 import { NgEntityServiceGlobalConfig, NG_ENTITY_SERVICE_CONFIG, defaultConfig } from './ng-entity-service.config';
 import { HttpMethod, NgEntityServiceNotifier } from './ng-entity-service-notifier';
@@ -24,10 +24,10 @@ describe('NgEntityService', () => {
             TestService,
             {
               provide: NG_ENTITY_SERVICE_CONFIG,
-              useValue: {} as NgEntityServiceGlobalConfig
-            }
+              useValue: {} as NgEntityServiceGlobalConfig,
+            },
           ],
-          imports: [HttpClientTestingModule]
+          imports: [HttpClientTestingModule],
         });
       });
 
@@ -48,12 +48,12 @@ describe('NgEntityService', () => {
               useValue: {
                 baseUrl: 'base-url',
                 httpMethods: {
-                  PUT: HttpMethod.PATCH
-                }
-              } as NgEntityServiceGlobalConfig
-            }
+                  PUT: HttpMethod.PATCH,
+                },
+              } as NgEntityServiceGlobalConfig,
+            },
           ],
-          imports: [HttpClientTestingModule]
+          imports: [HttpClientTestingModule],
         });
       });
 
@@ -66,8 +66,8 @@ describe('NgEntityService', () => {
             POST: HttpMethod.POST,
             PATCH: HttpMethod.PATCH,
             PUT: HttpMethod.PATCH,
-            DELETE: HttpMethod.DELETE
-          }
+            DELETE: HttpMethod.DELETE,
+          },
         });
       }));
     });
@@ -83,12 +83,12 @@ describe('NgEntityService', () => {
               useValue: {
                 baseUrl: 'base-url',
                 httpMethods: {
-                  PUT: HttpMethod.PATCH
-                }
-              } as NgEntityServiceGlobalConfig
-            }
+                  PUT: HttpMethod.PATCH,
+                },
+              } as NgEntityServiceGlobalConfig,
+            },
           ],
-          imports: [HttpClientTestingModule]
+          imports: [HttpClientTestingModule],
         });
       });
 
@@ -101,9 +101,9 @@ describe('NgEntityService', () => {
             POST: HttpMethod.POST,
             PATCH: HttpMethod.PATCH,
             PUT: HttpMethod.PATCH,
-            DELETE: HttpMethod.DELETE
+            DELETE: HttpMethod.DELETE,
           },
-          resourceName: 'decorator-res'
+          resourceName: 'decorator-res',
         });
       }));
     });
@@ -119,12 +119,12 @@ describe('NgEntityService', () => {
               useValue: {
                 baseUrl: 'base-url',
                 httpMethods: {
-                  PUT: HttpMethod.PATCH
-                }
-              } as NgEntityServiceGlobalConfig
-            }
+                  PUT: HttpMethod.PATCH,
+                },
+              } as NgEntityServiceGlobalConfig,
+            },
           ],
-          imports: [HttpClientTestingModule]
+          imports: [HttpClientTestingModule],
         });
       });
 
@@ -137,9 +137,9 @@ describe('NgEntityService', () => {
             POST: HttpMethod.POST,
             PATCH: HttpMethod.PATCH,
             PUT: HttpMethod.PATCH,
-            DELETE: HttpMethod.DELETE
+            DELETE: HttpMethod.DELETE,
           },
-          resourceName: 'inline-res'
+          resourceName: 'inline-res',
         });
       }));
     });
@@ -153,11 +153,11 @@ describe('NgEntityService', () => {
             {
               provide: NG_ENTITY_SERVICE_CONFIG,
               useValue: {
-                baseUrl: 'base-url'
-              } as NgEntityServiceGlobalConfig
-            }
+                baseUrl: 'base-url',
+              } as NgEntityServiceGlobalConfig,
+            },
           ],
-          imports: [HttpClientTestingModule]
+          imports: [HttpClientTestingModule],
         });
       });
 
@@ -170,9 +170,9 @@ describe('NgEntityService', () => {
             POST: HttpMethod.POST,
             PATCH: HttpMethod.PATCH,
             PUT: HttpMethod.PUT,
-            DELETE: HttpMethod.DELETE
+            DELETE: HttpMethod.DELETE,
           },
-          resourceName: 'inline-res'
+          resourceName: 'inline-res',
         });
       }));
     });
@@ -188,12 +188,12 @@ describe('NgEntityService', () => {
               useValue: {
                 baseUrl: 'base-url',
                 httpMethods: {
-                  GET: HttpMethod.POST
-                }
-              } as NgEntityServiceGlobalConfig
-            }
+                  GET: HttpMethod.POST,
+                },
+              } as NgEntityServiceGlobalConfig,
+            },
           ],
-          imports: [HttpClientTestingModule]
+          imports: [HttpClientTestingModule],
         });
       });
 
@@ -206,9 +206,9 @@ describe('NgEntityService', () => {
             POST: HttpMethod.POST,
             PATCH: HttpMethod.PATCH,
             PUT: HttpMethod.PUT,
-            DELETE: HttpMethod.DELETE
+            DELETE: HttpMethod.DELETE,
           },
-          resourceName: 'inline-res'
+          resourceName: 'inline-res',
         });
       }));
     });
@@ -223,10 +223,10 @@ describe('NgEntityService', () => {
           TestServiceWithDecoratorConfig,
           {
             provide: NG_ENTITY_SERVICE_CONFIG,
-            useValue: { baseUrl: 'base-url' } as NgEntityServiceGlobalConfig
-          }
+            useValue: { baseUrl: 'base-url' } as NgEntityServiceGlobalConfig,
+          },
         ],
-        imports: [HttpClientTestingModule]
+        imports: [HttpClientTestingModule],
       });
     });
 
@@ -248,10 +248,10 @@ describe('NgEntityService', () => {
           TestServiceWithDecoratorConfig,
           {
             provide: NG_ENTITY_SERVICE_CONFIG,
-            useValue: { baseUrl: 'base-url' } as NgEntityServiceGlobalConfig
-          }
+            useValue: { baseUrl: 'base-url' } as NgEntityServiceGlobalConfig,
+          },
         ],
-        imports: [HttpClientTestingModule]
+        imports: [HttpClientTestingModule],
       });
     });
 
@@ -277,10 +277,10 @@ describe('NgEntityService', () => {
           TestServiceWithInlineConfig,
           {
             provide: NG_ENTITY_SERVICE_CONFIG,
-            useValue: {} as NgEntityServiceGlobalConfig
-          }
+            useValue: {} as NgEntityServiceGlobalConfig,
+          },
         ],
-        imports: [HttpClientTestingModule]
+        imports: [HttpClientTestingModule],
       });
     });
 
@@ -297,7 +297,7 @@ describe('NgEntityService', () => {
         method: HttpMethod.GET,
         loading: true,
         entityId: undefined,
-        storeName: storeName
+        storeName: storeName,
       });
     }));
 
@@ -311,7 +311,7 @@ describe('NgEntityService', () => {
           method: HttpMethod.GET,
           loading: true,
           entityId,
-          storeName: storeName
+          storeName: storeName,
         });
       }
     ));
@@ -323,7 +323,7 @@ describe('NgEntityService', () => {
         const entityId = 123;
         const dummyData = {
           id: entityId,
-          foo: 'bar'
+          foo: 'bar',
         };
         service.get(entityId).subscribe(() => {
           expect(store.upsert).toHaveBeenCalledWith(entityId, dummyData);
@@ -363,7 +363,7 @@ describe('NgEntityService', () => {
         jest.spyOn(store, 'set');
         const dummyData = [
           { id: 1, foo: 'bar' },
-          { id: 2, foo: 'baz' }
+          { id: 2, foo: 'baz' },
         ];
         service.get().subscribe(() => {
           expect(store.set).toHaveBeenCalledWith(dummyData);
@@ -380,7 +380,7 @@ describe('NgEntityService', () => {
         jest.spyOn(store, 'add');
         const dummyData = [
           { id: 1, foo: 'bar' },
-          { id: 2, foo: 'baz' }
+          { id: 2, foo: 'baz' },
         ];
         service.get({ append: true }).subscribe(() => {
           expect(store.add).toHaveBeenCalledWith(dummyData);
@@ -397,7 +397,7 @@ describe('NgEntityService', () => {
         jest.spyOn(store, 'upsertMany');
         const dummyData = [
           { id: 1, foo: 'bar' },
-          { id: 2, foo: 'baz' }
+          { id: 2, foo: 'baz' },
         ];
         service.get({ upsert: true }).subscribe(() => {
           expect(store.upsertMany).toHaveBeenCalledWith(dummyData);
@@ -418,7 +418,7 @@ describe('NgEntityService', () => {
         jest.spyOn(store, 'replace');
         const dummyData = [
           { id: 1, foo: 'bar' },
-          { id: 2, foo: 'baz' }
+          { id: 2, foo: 'baz' },
         ];
         service.get({ skipWrite: true }).subscribe(() => {
           expect(store.upsert).toHaveBeenCalledTimes(0);
@@ -436,9 +436,9 @@ describe('NgEntityService', () => {
     it('should return result from request', inject([TestServiceWithInlineConfig, HttpTestingController], (service: TestServiceWithInlineConfig, httpMock: HttpTestingController) => {
       const dummyData = [
         { id: 1, foo: 'bar' },
-        { id: 2, foo: 'baz' }
+        { id: 2, foo: 'baz' },
       ];
-      service.get().subscribe(result => {
+      service.get().subscribe((result) => {
         expect(result).toEqual(dummyData);
       });
 
@@ -451,12 +451,12 @@ describe('NgEntityService', () => {
       (service: TestServiceWithInlineConfig, httpMock: HttpTestingController) => {
         const dummyData = [
           { id: 1, foo: 'bar' },
-          { id: 2, foo: 'baz' }
+          { id: 2, foo: 'baz' },
         ];
-        service.get({ mapResponseFn: res => res.map(x => ({ entityId: x.id, test: x.foo })) }).subscribe(result => {
+        service.get({ mapResponseFn: (res) => res.map((x) => ({ entityId: x.id, test: x.foo })) }).subscribe((result) => {
           expect(result).toEqual([
             { entityId: 1, test: 'bar' },
-            { entityId: 2, test: 'baz' }
+            { entityId: 2, test: 'baz' },
           ]);
         });
 
@@ -517,7 +517,7 @@ describe('NgEntityService', () => {
       (service: TestServiceWithInlineConfig, httpMock: HttpTestingController) => {
         service.get({ params: { foo: 'foo', bar: 'bar' } }).subscribe();
 
-        const req = httpMock.expectOne(x => x.url === service.api);
+        const req = httpMock.expectOne((x) => x.url === service.api);
         expect(req.request.params.get('foo')).toEqual('foo');
         expect(req.request.params.get('bar')).toEqual('bar');
         req.flush([]);
@@ -530,9 +530,32 @@ describe('NgEntityService', () => {
         const entityId = 123;
         service.get(entityId, { params: { foo: 'foo', bar: 'bar' } }).subscribe();
 
-        const req = httpMock.expectOne(x => x.url === `${service.api}/${entityId}`);
+        const req = httpMock.expectOne((x) => x.url === `${service.api}/${entityId}`);
         expect(req.request.params.get('foo')).toEqual('foo');
         expect(req.request.params.get('bar')).toEqual('bar');
+        req.flush([]);
+      }
+    ));
+
+    it('should add sub-resources to request URL when called with subResources config', inject(
+      [TestServiceWithInlineConfig, HttpTestingController],
+      (service: TestServiceWithInlineConfig, httpMock: HttpTestingController) => {
+        const subResources = ['sub-resource-1', '1', 'sub-resource-2', '2'];
+        const expectedUrl = `${service.api}/${subResources[0]}/${subResources[1]}/${subResources[2]}/${subResources[3]}`;
+        service.get({ subResources }).subscribe();
+        const req = httpMock.expectOne((x) => x.url === expectedUrl);
+        req.flush([]);
+      }
+    ));
+
+    it('should add sub-resources to request URL when called with id and subResources config', inject(
+      [TestServiceWithInlineConfig, HttpTestingController],
+      (service: TestServiceWithInlineConfig, httpMock: HttpTestingController) => {
+        const entityId = 1;
+        const subResources = ['sub-resource-1', '1', 'sub-resource-2', '2'];
+        const expectedUrl = `${service.api}/${entityId}/${subResources[0]}/${subResources[1]}/${subResources[2]}/${subResources[3]}`;
+        service.get(entityId, { subResources }).subscribe();
+        const req = httpMock.expectOne((x) => x.url === expectedUrl);
         req.flush([]);
       }
     ));
@@ -543,7 +566,7 @@ describe('NgEntityService', () => {
         jest.spyOn(notifier, 'dispatch');
         const dummyData = [
           { id: 1, foo: 'bar' },
-          { id: 2, foo: 'baz' }
+          { id: 2, foo: 'baz' },
         ];
         service.get().subscribe(() => {
           expect(notifier.dispatch).toHaveBeenCalledWith({
@@ -551,7 +574,7 @@ describe('NgEntityService', () => {
             type: 'success',
             payload: dummyData,
             method: HttpMethod.GET,
-            successMsg: undefined
+            successMsg: undefined,
           });
         });
 
@@ -566,7 +589,7 @@ describe('NgEntityService', () => {
         jest.spyOn(notifier, 'dispatch');
         const dummyData = [
           { id: 1, foo: 'bar' },
-          { id: 2, foo: 'baz' }
+          { id: 2, foo: 'baz' },
         ];
         const successMsg = 'Success test message...';
         service.get({ successMsg }).subscribe(() => {
@@ -575,7 +598,7 @@ describe('NgEntityService', () => {
             type: 'success',
             payload: dummyData,
             method: HttpMethod.GET,
-            successMsg
+            successMsg,
           });
         });
 
@@ -595,9 +618,9 @@ describe('NgEntityService', () => {
                 storeName,
                 type: 'error',
                 method: HttpMethod.GET,
-                errorMsg: undefined
+                errorMsg: undefined,
               })
-            )
+            ),
         });
 
         const req = httpMock.expectOne(service.api);
@@ -617,9 +640,9 @@ describe('NgEntityService', () => {
                 storeName,
                 type: 'error',
                 method: HttpMethod.GET,
-                errorMsg
+                errorMsg,
               })
-            )
+            ),
         });
 
         const req = httpMock.expectOne(service.api);
@@ -640,8 +663,8 @@ describe('NgEntityService', () => {
             storeName,
             loading: false,
             entityId: undefined,
-            method: HttpMethod.GET
-          }
+            method: HttpMethod.GET,
+          },
         ]);
       })
     ));
@@ -660,8 +683,8 @@ describe('NgEntityService', () => {
             storeName,
             loading: false,
             entityId,
-            method: HttpMethod.GET
-          }
+            method: HttpMethod.GET,
+          },
         ]);
       })
     ));
@@ -675,10 +698,10 @@ describe('NgEntityService', () => {
           TestServiceWithInlineConfig,
           {
             provide: NG_ENTITY_SERVICE_CONFIG,
-            useValue: {} as NgEntityServiceGlobalConfig
-          }
+            useValue: {} as NgEntityServiceGlobalConfig,
+          },
         ],
-        imports: [HttpClientTestingModule]
+        imports: [HttpClientTestingModule],
       });
     });
 
@@ -696,7 +719,7 @@ describe('NgEntityService', () => {
       expect(loader.dispatch).toHaveBeenCalledWith({
         method: HttpMethod.POST,
         loading: true,
-        storeName: storeName
+        storeName: storeName,
       });
     }));
 
@@ -738,7 +761,7 @@ describe('NgEntityService', () => {
 
     it('should return result from request', inject([TestServiceWithInlineConfig, HttpTestingController], (service: TestServiceWithInlineConfig, httpMock: HttpTestingController) => {
       const dummyEntity: TestEntity = { id: 1, foo: 'foo', bar: 123 };
-      service.add(dummyEntity).subscribe(result => {
+      service.add(dummyEntity).subscribe((result) => {
         expect(result).toEqual(dummyEntity);
       });
 
@@ -750,7 +773,7 @@ describe('NgEntityService', () => {
       [TestServiceWithInlineConfig, HttpTestingController],
       (service: TestServiceWithInlineConfig, httpMock: HttpTestingController) => {
         const dummyEntity: TestEntity = { id: 1, foo: 'foo', bar: 123 };
-        service.add(dummyEntity, { mapResponseFn: x => ({ entityId: x.id, test: x.foo }) }).subscribe(result => {
+        service.add(dummyEntity, { mapResponseFn: (x) => ({ entityId: x.id, test: x.foo }) }).subscribe((result) => {
           expect(result).toEqual({ entityId: 1, test: 'foo' });
         });
 
@@ -790,9 +813,21 @@ describe('NgEntityService', () => {
         const dummyEntity: TestEntity = { id: 1, foo: 'foo', bar: 123 };
         service.add(dummyEntity, { params: { foo: 'foo', bar: 'bar' } }).subscribe();
 
-        const req = httpMock.expectOne(x => x.url === service.api);
+        const req = httpMock.expectOne((x) => x.url === service.api);
         expect(req.request.params.get('foo')).toEqual('foo');
         expect(req.request.params.get('bar')).toEqual('bar');
+        req.flush([]);
+      }
+    ));
+
+    it('should add sub-resources to request URL when called with subResources config', inject(
+      [TestServiceWithInlineConfig, HttpTestingController],
+      (service: TestServiceWithInlineConfig, httpMock: HttpTestingController) => {
+        const dummyEntity: TestEntity = { id: 1, foo: 'foo', bar: 123 };
+        const subResources = ['sub-resource-1', '1', 'sub-resource-2', '2'];
+        const expectedUrl = `${service.api}/${subResources[0]}/${subResources[1]}/${subResources[2]}/${subResources[3]}`;
+        service.add(dummyEntity, { subResources }).subscribe();
+        const req = httpMock.expectOne((x) => x.url === expectedUrl);
         req.flush([]);
       }
     ));
@@ -808,7 +843,7 @@ describe('NgEntityService', () => {
             type: 'success',
             payload: dummyEntity,
             method: HttpMethod.POST,
-            successMsg: undefined
+            successMsg: undefined,
           });
         });
 
@@ -829,7 +864,7 @@ describe('NgEntityService', () => {
             type: 'success',
             payload: dummyEntity,
             method: HttpMethod.POST,
-            successMsg
+            successMsg,
           });
         });
 
@@ -850,9 +885,9 @@ describe('NgEntityService', () => {
                 storeName,
                 type: 'error',
                 method: HttpMethod.POST,
-                errorMsg: undefined
+                errorMsg: undefined,
               })
-            )
+            ),
         });
 
         const req = httpMock.expectOne(service.api);
@@ -873,9 +908,9 @@ describe('NgEntityService', () => {
                 storeName,
                 type: 'error',
                 method: HttpMethod.POST,
-                errorMsg
+                errorMsg,
               })
-            )
+            ),
         });
 
         const req = httpMock.expectOne(service.api);
@@ -896,8 +931,8 @@ describe('NgEntityService', () => {
           {
             storeName,
             loading: false,
-            method: HttpMethod.POST
-          }
+            method: HttpMethod.POST,
+          },
         ]);
       })
     ));
@@ -911,10 +946,10 @@ describe('NgEntityService', () => {
           TestServiceWithInlineConfig,
           {
             provide: NG_ENTITY_SERVICE_CONFIG,
-            useValue: {} as NgEntityServiceGlobalConfig
-          }
+            useValue: {} as NgEntityServiceGlobalConfig,
+          },
         ],
-        imports: [HttpClientTestingModule]
+        imports: [HttpClientTestingModule],
       });
     });
 
@@ -935,7 +970,7 @@ describe('NgEntityService', () => {
         method: HttpMethod.PUT,
         loading: true,
         entityId,
-        storeName: storeName
+        storeName: storeName,
       });
     }));
 
@@ -974,7 +1009,7 @@ describe('NgEntityService', () => {
     it('should return result from request', inject([TestServiceWithInlineConfig, HttpTestingController], (service: TestServiceWithInlineConfig, httpMock: HttpTestingController) => {
       const entityId = 1;
       const dummyEntity: Partial<TestEntity> = { foo: 'foo', bar: 123 };
-      service.update(entityId, dummyEntity).subscribe(result => {
+      service.update(entityId, dummyEntity).subscribe((result) => {
         expect(result).toEqual(dummyEntity);
       });
 
@@ -987,7 +1022,7 @@ describe('NgEntityService', () => {
       (service: TestServiceWithInlineConfig, httpMock: HttpTestingController) => {
         const entityId = 1;
         const dummyEntity: Partial<TestEntity> = { foo: 'foo', bar: 123 };
-        service.update(entityId, dummyEntity, { mapResponseFn: x => ({ test: x.foo, test2: x.bar }) }).subscribe(result => {
+        service.update(entityId, dummyEntity, { mapResponseFn: (x) => ({ test: x.foo, test2: x.bar }) }).subscribe((result) => {
           expect(result).toEqual({ test: 'foo', test2: 123 });
         });
 
@@ -1030,9 +1065,22 @@ describe('NgEntityService', () => {
         const dummyEntity: Partial<TestEntity> = { foo: 'foo', bar: 123 };
         service.update(entityId, dummyEntity, { params: { foo: 'foo', bar: 'bar' } }).subscribe();
 
-        const req = httpMock.expectOne(x => x.url === `${service.api}/${entityId}`);
+        const req = httpMock.expectOne((x) => x.url === `${service.api}/${entityId}`);
         expect(req.request.params.get('foo')).toEqual('foo');
         expect(req.request.params.get('bar')).toEqual('bar');
+        req.flush([]);
+      }
+    ));
+
+    it('should add sub-resources to request URL when called with subResources config', inject(
+      [TestServiceWithInlineConfig, HttpTestingController],
+      (service: TestServiceWithInlineConfig, httpMock: HttpTestingController) => {
+        const entityId = 1;
+        const dummyEntity: Partial<TestEntity> = { foo: 'foo', bar: 123 };
+        const subResources = ['sub-resource-1', '1', 'sub-resource-2', '2'];
+        const expectedUrl = `${service.api}/${entityId}/${subResources[0]}/${subResources[1]}/${subResources[2]}/${subResources[3]}`;
+        service.update(entityId, dummyEntity, { subResources }).subscribe();
+        const req = httpMock.expectOne((x) => x.url === expectedUrl);
         req.flush([]);
       }
     ));
@@ -1049,7 +1097,7 @@ describe('NgEntityService', () => {
             type: 'success',
             payload: dummyEntity,
             method: HttpMethod.PUT,
-            successMsg: undefined
+            successMsg: undefined,
           });
         });
 
@@ -1071,7 +1119,7 @@ describe('NgEntityService', () => {
             type: 'success',
             payload: dummyEntity,
             method: HttpMethod.PUT,
-            successMsg
+            successMsg,
           });
         });
 
@@ -1093,9 +1141,9 @@ describe('NgEntityService', () => {
                 storeName,
                 type: 'error',
                 method: HttpMethod.PUT,
-                errorMsg: undefined
+                errorMsg: undefined,
               })
-            )
+            ),
         });
 
         const req = httpMock.expectOne(`${service.api}/${entityId}`);
@@ -1117,9 +1165,9 @@ describe('NgEntityService', () => {
                 storeName,
                 type: 'error',
                 method: HttpMethod.PUT,
-                errorMsg
+                errorMsg,
               })
-            )
+            ),
         });
 
         const req = httpMock.expectOne(`${service.api}/${entityId}`);
@@ -1142,8 +1190,8 @@ describe('NgEntityService', () => {
             storeName,
             loading: false,
             entityId, // !WARN this is inconsistant with the stop loading event in both get & add, as they don't include entityId
-            method: HttpMethod.PUT
-          }
+            method: HttpMethod.PUT,
+          },
         ]);
       })
     ));
@@ -1157,10 +1205,10 @@ describe('NgEntityService', () => {
           TestServiceWithInlineConfig,
           {
             provide: NG_ENTITY_SERVICE_CONFIG,
-            useValue: {} as NgEntityServiceGlobalConfig
-          }
+            useValue: {} as NgEntityServiceGlobalConfig,
+          },
         ],
-        imports: [HttpClientTestingModule]
+        imports: [HttpClientTestingModule],
       });
     });
 
@@ -1179,7 +1227,7 @@ describe('NgEntityService', () => {
         method: HttpMethod.DELETE,
         loading: true,
         entityId,
-        storeName: storeName
+        storeName: storeName,
       });
     }));
 
@@ -1214,7 +1262,7 @@ describe('NgEntityService', () => {
     it('should return result from request', inject([TestServiceWithInlineConfig, HttpTestingController], (service: TestServiceWithInlineConfig, httpMock: HttpTestingController) => {
       const entityId = 1;
       const deleteResponse = { id: entityId, message: 'deleted' };
-      service.delete(entityId).subscribe(result => {
+      service.delete(entityId).subscribe((result) => {
         expect(result).toEqual(deleteResponse);
       });
 
@@ -1227,7 +1275,7 @@ describe('NgEntityService', () => {
       (service: TestServiceWithInlineConfig, httpMock: HttpTestingController) => {
         const entityId = 1;
         const deleteResponse = { id: entityId, message: 'deleted' };
-        service.delete(entityId, { mapResponseFn: x => ({ test: x.id, test2: x.message }) }).subscribe(result => {
+        service.delete(entityId, { mapResponseFn: (x) => ({ test: x.id, test2: x.message }) }).subscribe((result) => {
           expect(result).toEqual({ test: entityId, test2: 'deleted' });
         });
 
@@ -1267,9 +1315,21 @@ describe('NgEntityService', () => {
         const entityId = 1;
         service.delete(entityId, { params: { foo: 'foo', bar: 'bar' } }).subscribe();
 
-        const req = httpMock.expectOne(x => x.url === `${service.api}/${entityId}`);
+        const req = httpMock.expectOne((x) => x.url === `${service.api}/${entityId}`);
         expect(req.request.params.get('foo')).toEqual('foo');
         expect(req.request.params.get('bar')).toEqual('bar');
+        req.flush([]);
+      }
+    ));
+
+    it('should add sub-resources to request URL when called with subResources config', inject(
+      [TestServiceWithInlineConfig, HttpTestingController],
+      (service: TestServiceWithInlineConfig, httpMock: HttpTestingController) => {
+        const entityId = 1;
+        const subResources = ['sub-resource-1', '1', 'sub-resource-2', '2'];
+        const expectedUrl = `${service.api}/${entityId}/${subResources[0]}/${subResources[1]}/${subResources[2]}/${subResources[3]}`;
+        service.delete(entityId, { subResources }).subscribe();
+        const req = httpMock.expectOne((x) => x.url === expectedUrl);
         req.flush([]);
       }
     ));
@@ -1286,7 +1346,7 @@ describe('NgEntityService', () => {
             type: 'success',
             payload: deleteResponse,
             method: HttpMethod.DELETE,
-            successMsg: undefined
+            successMsg: undefined,
           });
         });
 
@@ -1308,7 +1368,7 @@ describe('NgEntityService', () => {
             type: 'success',
             payload: deleteResponse,
             method: HttpMethod.DELETE,
-            successMsg
+            successMsg,
           });
         });
 
@@ -1329,9 +1389,9 @@ describe('NgEntityService', () => {
                 storeName,
                 type: 'error',
                 method: HttpMethod.DELETE,
-                errorMsg: undefined
+                errorMsg: undefined,
               })
-            )
+            ),
         });
 
         const req = httpMock.expectOne(`${service.api}/${entityId}`);
@@ -1352,9 +1412,9 @@ describe('NgEntityService', () => {
                 storeName,
                 type: 'error',
                 method: HttpMethod.DELETE,
-                errorMsg
+                errorMsg,
               })
-            )
+            ),
         });
 
         const req = httpMock.expectOne(`${service.api}/${entityId}`);
@@ -1376,8 +1436,8 @@ describe('NgEntityService', () => {
             storeName,
             loading: false,
             entityId, // !WARN this is inconsistant with the stop loading event in both get & add, as they don't include entityId
-            method: HttpMethod.DELETE
-          }
+            method: HttpMethod.DELETE,
+          },
         ]);
       })
     ));

--- a/libs/akita-ng-entity-service/src/lib/ng-entity-service.spec.ts
+++ b/libs/akita-ng-entity-service/src/lib/ng-entity-service.spec.ts
@@ -1,18 +1,18 @@
-import { TestBed, inject, fakeAsync, tick } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { fakeAsync, inject, TestBed, tick } from '@angular/core/testing';
+import { HttpMethod, NgEntityServiceNotifier } from './ng-entity-service-notifier';
+import { defaultConfig, NgEntityServiceGlobalConfig, NG_ENTITY_SERVICE_CONFIG } from './ng-entity-service.config';
+import { NgEntityServiceLoader } from './ng-entity-service.loader';
 import {
-  TestStore,
-  TestServiceWithDecoratorConfig,
-  TestServiceWithDecoratorAndInlineConfig,
-  TestService,
-  TestServiceWithInlineConfig,
-  TestServiceWithMixedConfig,
   storeName,
   TestEntity,
+  TestService,
+  TestServiceWithDecoratorAndInlineConfig,
+  TestServiceWithDecoratorConfig,
+  TestServiceWithInlineConfig,
+  TestServiceWithMixedConfig,
+  TestStore,
 } from './setup';
-import { NgEntityServiceGlobalConfig, NG_ENTITY_SERVICE_CONFIG, defaultConfig } from './ng-entity-service.config';
-import { HttpMethod, NgEntityServiceNotifier } from './ng-entity-service-notifier';
-import { NgEntityServiceLoader } from './ng-entity-service.loader';
 
 describe('NgEntityService', () => {
   describe('should merge config in order...', () => {
@@ -537,24 +537,24 @@ describe('NgEntityService', () => {
       }
     ));
 
-    it('should add sub-resources to request URL when called with subResources config', inject(
+    it('should add URL postfix to request URL when called with urlPostfix config', inject(
       [TestServiceWithInlineConfig, HttpTestingController],
       (service: TestServiceWithInlineConfig, httpMock: HttpTestingController) => {
-        const subResources = ['sub-resource-1', '1', 'sub-resource-2', '2'];
-        const expectedUrl = `${service.api}/${subResources[0]}/${subResources[1]}/${subResources[2]}/${subResources[3]}`;
-        service.get({ subResources }).subscribe();
+        const urlPostfix = 'foo/3/bar/3';
+        const expectedUrl = `${service.api}/${urlPostfix}`;
+        service.get({ urlPostfix }).subscribe();
         const req = httpMock.expectOne((x) => x.url === expectedUrl);
         req.flush([]);
       }
     ));
 
-    it('should add sub-resources to request URL when called with id and subResources config', inject(
+    it('should add URL postfix to request URL when called with id and urlPostfix config', inject(
       [TestServiceWithInlineConfig, HttpTestingController],
       (service: TestServiceWithInlineConfig, httpMock: HttpTestingController) => {
         const entityId = 1;
-        const subResources = ['sub-resource-1', '1', 'sub-resource-2', '2'];
-        const expectedUrl = `${service.api}/${entityId}/${subResources[0]}/${subResources[1]}/${subResources[2]}/${subResources[3]}`;
-        service.get(entityId, { subResources }).subscribe();
+        const urlPostfix = 'foo/3/bar/3';
+        const expectedUrl = `${service.api}/${entityId}/${urlPostfix}`;
+        service.get(entityId, { urlPostfix }).subscribe();
         const req = httpMock.expectOne((x) => x.url === expectedUrl);
         req.flush([]);
       }
@@ -820,13 +820,13 @@ describe('NgEntityService', () => {
       }
     ));
 
-    it('should add sub-resources to request URL when called with subResources config', inject(
+    it('should add URL postfix to request URL when called with urlPostfix config', inject(
       [TestServiceWithInlineConfig, HttpTestingController],
       (service: TestServiceWithInlineConfig, httpMock: HttpTestingController) => {
         const dummyEntity: TestEntity = { id: 1, foo: 'foo', bar: 123 };
-        const subResources = ['sub-resource-1', '1', 'sub-resource-2', '2'];
-        const expectedUrl = `${service.api}/${subResources[0]}/${subResources[1]}/${subResources[2]}/${subResources[3]}`;
-        service.add(dummyEntity, { subResources }).subscribe();
+        const urlPostfix = 'foo/3/bar/3';
+        const expectedUrl = `${service.api}/${urlPostfix}`;
+        service.add(dummyEntity, { urlPostfix }).subscribe();
         const req = httpMock.expectOne((x) => x.url === expectedUrl);
         req.flush([]);
       }
@@ -1072,14 +1072,14 @@ describe('NgEntityService', () => {
       }
     ));
 
-    it('should add sub-resources to request URL when called with subResources config', inject(
+    it('should add URL postfix to request URL when called with urlPostfix config', inject(
       [TestServiceWithInlineConfig, HttpTestingController],
       (service: TestServiceWithInlineConfig, httpMock: HttpTestingController) => {
         const entityId = 1;
         const dummyEntity: Partial<TestEntity> = { foo: 'foo', bar: 123 };
-        const subResources = ['sub-resource-1', '1', 'sub-resource-2', '2'];
-        const expectedUrl = `${service.api}/${entityId}/${subResources[0]}/${subResources[1]}/${subResources[2]}/${subResources[3]}`;
-        service.update(entityId, dummyEntity, { subResources }).subscribe();
+        const urlPostfix = 'foo/3/bar/3';
+        const expectedUrl = `${service.api}/${entityId}/${urlPostfix}`;
+        service.update(entityId, dummyEntity, { urlPostfix }).subscribe();
         const req = httpMock.expectOne((x) => x.url === expectedUrl);
         req.flush([]);
       }
@@ -1322,13 +1322,13 @@ describe('NgEntityService', () => {
       }
     ));
 
-    it('should add sub-resources to request URL when called with subResources config', inject(
+    it('should add URL postfix to request URL when called with urlPostfix config', inject(
       [TestServiceWithInlineConfig, HttpTestingController],
       (service: TestServiceWithInlineConfig, httpMock: HttpTestingController) => {
         const entityId = 1;
-        const subResources = ['sub-resource-1', '1', 'sub-resource-2', '2'];
-        const expectedUrl = `${service.api}/${entityId}/${subResources[0]}/${subResources[1]}/${subResources[2]}/${subResources[3]}`;
-        service.delete(entityId, { subResources }).subscribe();
+        const urlPostfix = 'foo/3/bar/3';
+        const expectedUrl = `${service.api}/${entityId}/${urlPostfix}`;
+        service.delete(entityId, { urlPostfix }).subscribe();
         const req = httpMock.expectOne((x) => x.url === expectedUrl);
         req.flush([]);
       }

--- a/libs/akita-ng-entity-service/src/lib/ng-entity.service.ts
+++ b/libs/akita-ng-entity-service/src/lib/ng-entity.service.ts
@@ -327,7 +327,7 @@ export class NgEntityService<S extends EntityState = any> extends EntityService<
   }
 
   protected resolveUrl(config?: HttpConfig, id?: any) {
-    const { url, subResources } = Object(config) as HttpConfig;
+    const { url, urlPostfix } = Object(config) as HttpConfig;
     let final = this.api;
 
     if (url) {
@@ -338,8 +338,8 @@ export class NgEntityService<S extends EntityState = any> extends EntityService<
       final += `/${id}`;
     }
 
-    if (subResources && subResources.length > 0) {
-      final += `/${subResources.join('/')}`;
+    if (urlPostfix) {
+      final += `/${urlPostfix}`;
     }
 
     return final;

--- a/libs/akita-ng-entity-service/src/lib/ng-entity.service.ts
+++ b/libs/akita-ng-entity-service/src/lib/ng-entity.service.ts
@@ -1,14 +1,14 @@
+import { HttpClient } from '@angular/common/http';
+import { inject } from '@angular/core';
 import { EntityService, EntityState, EntityStore, getEntityType, getIDType, isDefined } from '@datorama/akita';
 import { Observable, throwError } from 'rxjs';
-import { inject } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
 import { catchError, finalize, map, tap } from 'rxjs/operators';
-import { HttpConfig, HttpAddConfig, HttpGetConfig, HttpDeleteConfig, HttpUpdateConfig, NgEntityServiceParams } from './types';
-import { EntityServiceAction, HttpMethod, NgEntityServiceNotifier } from './ng-entity-service-notifier';
-import { NgEntityServiceLoader } from './ng-entity-service.loader';
-import { defaultConfig, mergeDeep, NG_ENTITY_SERVICE_CONFIG, NgEntityServiceGlobalConfig } from './ng-entity-service.config';
-import { isID } from './helpers';
 import { errorAction, successAction } from './action-factory';
+import { isID } from './helpers';
+import { EntityServiceAction, HttpMethod, NgEntityServiceNotifier } from './ng-entity-service-notifier';
+import { defaultConfig, mergeDeep, NgEntityServiceGlobalConfig, NG_ENTITY_SERVICE_CONFIG } from './ng-entity-service.config';
+import { NgEntityServiceLoader } from './ng-entity-service.loader';
+import { HttpAddConfig, HttpConfig, HttpDeleteConfig, HttpGetConfig, HttpUpdateConfig, NgEntityServiceParams } from './types';
 
 export const mapResponse = <T>(config?: HttpConfig<T>) => map((res) => (config && !!config.mapResponseFn ? config.mapResponseFn(res) : res));
 
@@ -327,11 +327,22 @@ export class NgEntityService<S extends EntityState = any> extends EntityService<
   }
 
   protected resolveUrl(config?: HttpConfig, id?: any) {
-    if (config && config.url) {
-      return config.url;
+    const { url, subResources } = Object(config) as HttpConfig;
+    let final = this.api;
+
+    if (url) {
+      return url;
     }
 
-    return isDefined(id) ? `${this.api}/${id}` : this.api;
+    if (isDefined(id)) {
+      final += `/${id}`;
+    }
+
+    if (subResources && subResources.length > 0) {
+      final += `/${subResources.join('/')}`;
+    }
+
+    return final;
   }
 
   protected handleError(method: HttpMethod, error: any, errorMsg?: string) {

--- a/libs/akita-ng-entity-service/src/lib/types.ts
+++ b/libs/akita-ng-entity-service/src/lib/types.ts
@@ -28,7 +28,7 @@ export type HttpConfig<Entity = any> = {
   params?: _HttpParams;
   headers?: _HttpHeaders;
   url?: string;
-  subResources?: string[];
+  urlPostfix?: string;
   mapResponseFn?: (res: any) => Entity | Entity[];
 };
 

--- a/libs/akita-ng-entity-service/src/lib/types.ts
+++ b/libs/akita-ng-entity-service/src/lib/types.ts
@@ -28,6 +28,7 @@ export type HttpConfig<Entity = any> = {
   params?: _HttpParams;
   headers?: _HttpHeaders;
   url?: string;
+  subResources?: string[];
   mapResponseFn?: (res: any) => Entity | Entity[];
 };
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

**Some possible use cases**
```
/posts/:postId/comments/:commentId
/users/:userId/articles/:articleId

/users/:userName/repos
/repos/:repoName/users
```
Currently, there's no way to specify sub-resources in the NgEntityService, so if you need a use case like the ones above, you'll have to override the whole API URL in the `url` property.

Issue Number: #562

## What is the new behavior?

With the new property "subResources" in the `httpConfig` type, now is possible to specify sub-resources in a form of an array. For example, if you need to get the articles of a certain user, you can do as follows:

```ts
// base: "https://api.example.com/v1"
// main resource: "users"

const userId = 1;
const articleId = 99;

this.usersService.get(userId, {
  urlPostfix: `articles/${articleId.toString}`
}).subscribe();
```

the final URL is: `https://api.example.com/v1/users/1/articles/99`

`users/1`   ---> main resource
`articles/99 `  ---> sub resource

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No