### PR TITLE
docs: Fix link

### DIFF
--- a/docs/docs/best-practices.mdx
+++ b/docs/docs/best-practices.mdx
@@ -59,7 +59,7 @@ class ArticlesStore extends EntityStore<ArticlesState> {
 }
 ```
 
-In most cases, there is no need to create a separate entity store for the `comments`. Instead use Akita's [Array Utils](additional/array). This will keep your store easier to maintain and use. If you still require a separate store, check out this article for tips on how to combine their data:
+In most cases, there is no need to create a separate entity store for the `comments`. Instead use Akita's [Array Utils](additional/array.mdx). This will keep your store easier to maintain and use. If you still require a separate store, check out this article for tips on how to combine their data:
 
 - [Working with Normalized Data in Akita and Angular](https://netbasal.com/working-with-normalized-data-in-akita-e626d4c67ca4)
 - [Introducing One To Many Relationship in Angular & Akita](https://dev.to/arielgueta/introducing-one-to-many-relationship-in-angular-akita-37me)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Link to "Array Utils" in [best practices](https://datorama.github.io/akita/docs/best-practices/#the-query) links to 404 page: https://datorama.github.io/akita/docs/best-practices/additional/array

## What is the new behavior?

Fix link to point to https://datorama.github.io/akita/docs/additional/array

This works in a similar instance: [config.mdx](https://github.com/datorama/akita/blob/ea131a5/docs/docs/config.mdx) links to `additional/` pages in https://datorama.github.io/akita/docs/config/

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
