### PR TITLE
docs(devtools): fix broken image

### DIFF
--- a/docs/docs/enhancers/devtools.mdx
+++ b/docs/docs/enhancers/devtools.mdx
@@ -2,9 +2,11 @@
 title: Devtools
 ---
 
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
 Akita provides integration with the Redux dev-tools chrome extension. 
 
-<img src="../../img/devtools.gif" class="gif" />
+<img src={useBaseUrl('static/img/devtools.gif')} class="gif" />
 
 ## Usage
 Install the Redux extension from the supported App stores ( [Chrome](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en), [Firefox](https://addons.mozilla.org/en-US/firefox/addon/reduxdevtools/) ).


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

https://datorama.github.io/akita/docs/enhancers/devtools/
![image](https://user-images.githubusercontent.com/26336/103233684-4d90d900-4903-11eb-87b2-370b6cd08ca1.png)

404: https://datorama.github.io/akita/docs/img/devtools.gif

## What is the new behavior?

Use [`useBaseUrl`](https://v2.docusaurus.io/docs/static-assets/) to fetch image

`yarn start`
![image](https://user-images.githubusercontent.com/26336/103233757-7d3fe100-4903-11eb-99b3-efa227b3f6f4.png)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
