### PR TITLE
docs(ui): definite assignment assertion modifiers for initial state

### DIFF
--- a/docs/docs/ui.mdx
+++ b/docs/docs/ui.mdx
@@ -110,8 +110,19 @@ export class MoviesStore extends EntityStore<MoviesState> {
     super();
     const defaults = { isLoading: false, isOpen: true };
     this.createUIStore().setInitialEntityState(defaults);
-    
-    // Or if you need the entity object
+  }
+}
+```
+
+Or if you need the entity object:
+
+```ts {7,8} title="movies.store.ts"
+@StoreConfig({ name: 'movies' })
+export class MoviesStore extends EntityStore<MoviesState> {
+  // Note the ! modifier, as defaults are assigned via side-effect
+  ui!: EntityUIStore<MoviesUIState>;
+
+  constructor() {
     const defaults = entity => ({ isLoading: false, isOpen: true });
     this.createUIStore().setInitialEntityState(defaults);
   }


### PR DESCRIPTION
Fixes a type error that'd come up when functions initialize properties in the constructor.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

![image](https://user-images.githubusercontent.com/26336/103324012-1dccf880-4a0b-11eb-81f0-27e8273cca93.png)


## What is the new behavior?

Note the _definite assignment assertion modifiers_ (introduction in [TypeScript 2.7](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#strict-class-initialization))

![image](https://user-images.githubusercontent.com/26336/103323479-9aaaa300-4a08-11eb-95ca-d433585ecdaf.png)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
