### PR TITLE
refactor(schematics): Add support for nx workspace.json

### DIFF
--- a/libs/akita-schematics/src/ng-g/utils/workspace.ts
+++ b/libs/akita-schematics/src/ng-g/utils/workspace.ts
@@ -129,7 +129,7 @@ export interface AppConfig {
 export type WorkspaceSchema = experimental.workspace.WorkspaceSchema;
 
 export function getWorkspacePath(host: Tree): string {
-  const possibleFiles = ['/angular.json', '/.angular.json'];
+  const possibleFiles = ['/angular.json', '/.angular.json', '/workspace.json'];
   const path = possibleFiles.filter(path => host.exists(path))[0];
 
   return path;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ X ] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [ ? ] Tests for the changes have been added (for bug fixes / features)
- [ ? ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ X ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

When using the `@datorama/akita` schematics with the `nx` command it fails as it's only looking for `angular.json`.

## What is the new behavior?

NX Monorepo `workspace.json` is the same format for the requirements of running a schematic, this adds support to run the schematics using the `nx` command.

e.g.
`nx g @datorama/akita:af core-state --plain --project=core-api`

## Does this PR introduce a breaking change?

- [ ] Yes
- [ X ] No

