### PR TITLE
docs: pluralize effects module import code snippet

### DIFF
--- a/docs/docs/angular/effects.mdx
+++ b/docs/docs/angular/effects.mdx
@@ -11,23 +11,23 @@ npm i @datorama/akita-ng-effects
 Next, to register effects, simply run `AkitaNgEffects.forRoot()` and register the effect classes:
 
 ```ts title="app.module.ts"
-import { AkitaNgEffectModule } from '@datorama/akita-ng-effects';
+import { AkitaNgEffectsModule } from '@datorama/akita-ng-effects';
 import { NavigationEffects } from './path/to/effects';
 
 // Only use .forRoot() once in your base module.
 @NgModule({
-  imports: [CommonModule, AkitaNgEffectModule.forRoot([NavigationEffects])],
+  imports: [CommonModule, AkitaNgEffectsModule.forRoot([NavigationEffects])],
 })
 export class AppModule {}
 ```
 
 ```ts title="product.module.ts"
-import { AkitaNgEffectModule } from '@datorama/akita';
+import { AkitaNgEffectsModule } from '@datorama/akita-ng-effects';
 import { ProductEffects } from './path/to/effects';
 
 // Use .forFeature() on any feature module
 @NgModule({
-  imports: [CommonModule, AkitaNgEffectModule.forFeature([ProductEffects])],
+  imports: [CommonModule, AkitaNgEffectsModule.forFeature([ProductEffects])],
 })
 export class FeatureModule {}
 ```


### PR DESCRIPTION
updating code snippet to reflect pluralized import module name

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

When copying the code snippet I see ```../../node_modules/@datorama/akita-ng-effects/datorama-akita-ng-effects"' has no exported member named 'AkitaNgEffectModule'. Did you mean 'AkitaNgEffectsModule'?``` inside of angular project.

Issue Number: N/A

## What is the new behavior?

Correctly imports the declared module.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
