### PR TITLE
feat: make DirtyCheck's getHead() public

### DIFF
--- a/docs/docs/plugins/dirty-check.mdx
+++ b/docs/docs/plugins/dirty-check.mdx
@@ -22,7 +22,7 @@ export class WidgetsComponent {
   reset() {
     this.dirtyCheck.reset();
   }
-  
+
   ngOnDestroy() {
     this.dirtyCheck.destroy();
   }
@@ -32,11 +32,7 @@ export class WidgetsComponent {
 From the moment you call `setHead()`, Akita's `DirtyCheckPlugin` takes the current store snapshot and saves it as the head (the value that we compare against). With every change to the store the plugin will compare it to the head value and notify you whether the state is dirty.
 
 ```html title="widgets.component.html"
-<button
-    [disabled]="!(dirtyCheck.isDirty$| async)" 
-    (click)="save()">
-  Save Changes
-</button>
+<button [disabled]="!(dirtyCheck.isDirty$| async)" (click)="save()">Save Changes</button>
 ```
 
 By calling `reset()` you are telling the plugin to update the store with the `head` value. The plugin also provides a special method called isPathDirty() that checks whether a given `path` is `dirty`. For example:
@@ -46,9 +42,12 @@ const dirtyCheck = new DirtyCheckPlugin(widgetsQuery).setHead();
 dirtyCheck.isPathDirty('check.this.path');
 ```
 
+If you have set the head, you can get the current head value with `getHead()`.
+
 ## Options
 
 ### `comparator`
+
 The default `comparator` compares the object by using the native `JSON.stringify()` method, but you can pass a custom `comparator`, for example:
 
 ```ts
@@ -59,13 +58,15 @@ const dirtyCheck = new DirtyCheckPlugin(widgetsQuery, options);
 ```
 
 ### `watchProperty`
+
 The dirty check plugin can watch specific properties in your store's state and not just the entire store, this can be achieved by passing the properties keys to `DirtyCheckPlugin`, for example:
+
 ```ts
 // Tracks the entire store
 new DirtyCheckPlugin(widgetsQuery);
 
 // Tracks the store's state name property
-new DirtyCheckPlugin(widgetsQuery, { watchProperty: 'name' }); 
+new DirtyCheckPlugin(widgetsQuery, { watchProperty: 'name' });
 
 // Tracks a set of properties
 new DirtyCheckPlugin(widgetsQuery, { watchProperty: ['name', 'color'] });
@@ -78,7 +79,7 @@ After the first time you call `setHead()`, each subsequent call to this method w
 
 ## EntityDirtyCheckPlugin
 
-In addition to the general dirty check functionality,  Akita also provides a powerful API to help keep track of one or many entities, instead of the entire store. 
+In addition to the general dirty check functionality, Akita also provides a powerful API to help keep track of one or many entities, instead of the entire store.
 
 A good example is when you have a table or a list of entities that the users can modify, and you want to give them a way to revert it per entity. Here is how you can do it:
 
@@ -103,32 +104,26 @@ export class WidgetsComponent {
   reset(ids) {
     this.collection.reset(ids);
   }
-  
+
   ngOnDestroy() {
     this.collection.destroy();
   }
 }
 ```
 
-With this setup you can track the dirtiness per entity and revert it. 
-
+With this setup you can track the dirtiness per entity and revert it.
 
 ```html title="widgets.component.html"
 <tbody>
   <tr *ngFor="let widget of widgets$ | async">
     <td>
-      <input [value]="widget.name" #name>
+      <input [value]="widget.name" #name />
     </td>
     <td>
-      <button (click)="updateWidget(widget.id, name.value)">
-        Save
-      </button>
+      <button (click)="updateWidget(widget.id, name.value)">Save</button>
     </td>
     <td>
-      <button (click)="revert(widget.id)"
-              [disabled]="!(collection.isDirty(widget.id) | async)">
-        Revert
-      </button>
+      <button (click)="revert(widget.id)" [disabled]="!(collection.isDirty(widget.id) | async)">Revert</button>
     </td>
   </tr>
 </tbody>
@@ -144,7 +139,7 @@ Sometimes it's useful to partially reset the entity value when clicking on rever
 const updateFn = (head, current) => {
   return {
     ...head,
-    title: current.title
+    title: current.title,
   };
 };
 
@@ -154,6 +149,7 @@ collection.reset(entityId, { updateFn });
 In the above example we are reverting the whole entity except for the `title` (note that this will still mark the entity as dirty).
 
 Sometimes it's also useful to check whether at least one of the entities is dirty. For this you can use the `someDirty()` method:
+
 ```ts
 collection.someDirty().subscribe(console.log);
 ```
@@ -161,11 +157,10 @@ collection.someDirty().subscribe(console.log);
 ### Options
 
 ### `entityIds`
+
 A single id or an array of entity ids (default: all).
 
 ```ts
 const options = { entityIds: [1, 2] };
 stateHistory = new EntityDirtyCheckPlugin(widgetsQuery, options);
 ```
-
-

--- a/libs/akita/src/__tests__/dirtyCheck.spec.ts
+++ b/libs/akita/src/__tests__/dirtyCheck.spec.ts
@@ -7,7 +7,7 @@ describe('DirtyCheck', () => {
   function createWidget() {
     return {
       id: ++_id,
-      title: `Widget ${_id}`
+      title: `Widget ${_id}`,
     } as Widget;
   }
 
@@ -37,16 +37,16 @@ describe('DirtyCheck', () => {
         widgetsStore.add(createWidget());
         expect(spy).toHaveBeenLastCalledWith(false);
         dirtyCheck.setHead();
-        expect(dirtyCheck.head).toEqual({
+        expect(dirtyCheck.getHead()).toEqual({
           entities: {
             '1': {
               id: 1,
-              title: 'Widget 1'
-            }
+              title: 'Widget 1',
+            },
           },
           error: null,
           ids: [1],
-          loading: false
+          loading: false,
         });
         expect(spy).toHaveBeenLastCalledWith(false);
       });
@@ -66,21 +66,21 @@ describe('DirtyCheck', () => {
         expect(spy).toHaveBeenLastCalledWith(true);
         dirtyCheck.setHead();
         expect(spy).toHaveBeenLastCalledWith(false);
-        expect(dirtyCheck.head).toEqual({
+        expect(dirtyCheck.getHead()).toEqual({
           entities: {
             '1': {
               id: 1,
-              title: 'Widget 1'
+              title: 'Widget 1',
             },
             '3': {
               id: 3,
-              title: 'Widget 3'
-            }
+              title: 'Widget 3',
+            },
           },
 
           error: null,
           ids: [1, 3],
-          loading: false
+          loading: false,
         });
       });
 
@@ -92,16 +92,16 @@ describe('DirtyCheck', () => {
           entities: {
             '1': {
               id: 1,
-              title: 'Widget 1'
+              title: 'Widget 1',
             },
             '3': {
               id: 3,
-              title: 'Widget 3'
-            }
+              title: 'Widget 3',
+            },
           },
           error: null,
           ids: [1, 3],
-          loading: false
+          loading: false,
         });
 
         expect(spy).toHaveBeenLastCalledWith(false);
@@ -140,7 +140,7 @@ describe('DirtyCheck', () => {
         const widgetsStore = new WidgetsStore({ some: { nested: { value: '' } } });
         const widgetsQuery = new WidgetsQuery(widgetsStore);
         const dirtyCheck = new DirtyCheckPlugin(widgetsQuery);
-        it('should not return dirty for isPathDirty', function() {
+        it('should not return dirty for isPathDirty', function () {
           let isPathDirty: boolean;
           dirtyCheck.setHead();
           isPathDirty = dirtyCheck.isPathDirty('some.nested.value');
@@ -149,9 +149,9 @@ describe('DirtyCheck', () => {
           widgetsStore.update({
             some: {
               nested: {
-                value: 'other value'
-              }
-            }
+                value: 'other value',
+              },
+            },
           });
 
           isPathDirty = dirtyCheck.isPathDirty('some.nested.value');
@@ -164,9 +164,9 @@ describe('DirtyCheck', () => {
           widgetsStore.update({
             some: {
               nested: {
-                value: 'other value'
-              }
-            }
+                value: 'other value',
+              },
+            },
           });
 
           isPathDirty = dirtyCheck.isPathDirty('some.nested.value');
@@ -175,24 +175,24 @@ describe('DirtyCheck', () => {
           widgetsStore.update({
             some: {
               nested: {
-                value: ''
-              }
-            }
+                value: '',
+              },
+            },
           });
 
           isPathDirty = dirtyCheck.isPathDirty('some.nested.value');
           expect(isPathDirty).toBeFalsy();
         });
 
-        it('should return dirty for isPathDirty', function() {
+        it('should return dirty for isPathDirty', function () {
           let isPathDirty: boolean;
           dirtyCheck.setHead();
           widgetsStore.update({
             some: {
               nested: {
-                value: 'some other name'
-              }
-            }
+                value: 'some other name',
+              },
+            },
           });
 
           isPathDirty = dirtyCheck.isPathDirty('some.nested.value');
@@ -205,9 +205,9 @@ describe('DirtyCheck', () => {
           widgetsStore.update({
             some: {
               nested: {
-                value: 'some other name'
-              }
-            }
+                value: 'some other name',
+              },
+            },
           });
 
           isPathDirty = dirtyCheck.isPathDirty('some.nested.value');
@@ -216,9 +216,9 @@ describe('DirtyCheck', () => {
           widgetsStore.update({
             some: {
               nested: {
-                value: ''
-              }
-            }
+                value: '',
+              },
+            },
           });
 
           isPathDirty = dirtyCheck.isPathDirty('some.nested.value');
@@ -227,9 +227,9 @@ describe('DirtyCheck', () => {
           widgetsStore.update({
             some: {
               nested: {
-                value: 'some value'
-              }
-            }
+                value: 'some value',
+              },
+            },
           });
 
           isPathDirty = dirtyCheck.isPathDirty('some.nested.value');
@@ -274,7 +274,7 @@ describe('DirtyCheck', () => {
     const spy = jest.fn();
     dirtyCheck.isDirty$.pipe(skip(1)).subscribe(spy);
     it(`should watch 'ids' property if 'entities' is watched`, () => {
-      const watching = !['entities', 'ids'].some(key => !(dirtyCheck.params.watchProperty as any[]).includes(key));
+      const watching = !['entities', 'ids'].some((key) => !(dirtyCheck.params.watchProperty as any[]).includes(key));
       expect(watching).toBe(true);
     });
 
@@ -340,7 +340,7 @@ describe('DirtyCheckEntity', () => {
     return {
       id: ++_id,
       title: `Widget ${_id}`,
-      complete
+      complete,
     } as Widget;
   }
 
@@ -376,7 +376,7 @@ describe('DirtyCheckEntity', () => {
       const updateFn = (head, current) => {
         return {
           ...head,
-          title: current.title
+          title: current.title,
         };
       };
       collection.reset(1, { updateFn });
@@ -391,7 +391,7 @@ describe('DirtyCheckEntity', () => {
       collection.setHead();
       let expectedResult = false;
       let isDirty = collection.someDirty();
-      const subscription = collection.someDirty$.subscribe(res => {
+      const subscription = collection.someDirty$.subscribe((res) => {
         isDirty = collection.someDirty();
         expect(isDirty).toBe(expectedResult);
         expect(res).toBe(expectedResult);
@@ -449,7 +449,7 @@ describe('DirtyCheckEntity', () => {
     });
 
     describe('dirtyPath', () => {
-      it('should not return dirty for isPathDirty', function() {
+      it('should not return dirty for isPathDirty', function () {
         let isPathDirty: boolean;
         const widget = createWidget();
         widgetsStore.add(widget);
@@ -474,7 +474,7 @@ describe('DirtyCheckEntity', () => {
         expect(isPathDirty).toBeFalsy();
       });
 
-      it('should return dirty for isPathDirty', function() {
+      it('should return dirty for isPathDirty', function () {
         let isPathDirty: boolean;
         let widget = createWidget();
         widgetsStore.add(widget);
@@ -485,7 +485,7 @@ describe('DirtyCheckEntity', () => {
 
         widgetsStore.update(widget.id, {
           ...widget,
-          title: 'some other name'
+          title: 'some other name',
         });
 
         isPathDirty = collection.isPathDirty(widget.id, 'title');
@@ -493,7 +493,7 @@ describe('DirtyCheckEntity', () => {
 
         widgetsStore.update(widget.id, {
           ...widget,
-          title: `Widget ${widget.id}`
+          title: `Widget ${widget.id}`,
         });
 
         isPathDirty = collection.isPathDirty(widget.id, 'title');
@@ -501,7 +501,7 @@ describe('DirtyCheckEntity', () => {
 
         widgetsStore.update(widget.id, {
           ...widget,
-          title: 'some other name'
+          title: 'some other name',
         });
 
         isPathDirty = collection.isPathDirty(widget.id, 'title');
@@ -542,7 +542,7 @@ describe('DirtyCheckEntity', () => {
       const updateFn = (head, current) => {
         return {
           ...head,
-          title: current.title
+          title: current.title,
         };
       };
       collection.reset(1, { updateFn });
@@ -561,12 +561,12 @@ describe('DirtyCheckEntity', () => {
       let isDirty = collection.someDirty();
       const spy = jest.fn();
       const subscription = [
-        collection.someDirty$.subscribe(res => {
+        collection.someDirty$.subscribe((res) => {
           isDirty = collection.someDirty();
           expect(isDirty).toBe(expectedResult);
           expect(res).toBe(expectedResult);
         }),
-        collection.someDirty$.subscribe(spy)
+        collection.someDirty$.subscribe(spy),
       ];
       expect(isDirty).toBe(expectedResult);
       jest.runAllTimers();
@@ -601,7 +601,7 @@ describe('DirtyCheckEntity', () => {
       expect(isDirty).toBe(expectedResult);
       jest.runAllTimers();
       expect(spy).toBeCalledTimes(7);
-      subscription.forEach(s => s.unsubscribe());
+      subscription.forEach((s) => s.unsubscribe());
     });
 
     it('someDirty should return false when calling set head', () => {
@@ -613,10 +613,10 @@ describe('DirtyCheckEntity', () => {
       const spy = jest.fn();
       let expectedResult = false;
       const subscription = [
-        collection.someDirty$.subscribe(res => {
+        collection.someDirty$.subscribe((res) => {
           expect(res).toBe(expectedResult);
         }),
-        collection.someDirty$.subscribe(spy)
+        collection.someDirty$.subscribe(spy),
       ];
       jest.runAllTimers();
       collection.setHead();
@@ -638,7 +638,7 @@ describe('DirtyCheckEntity', () => {
       expectedResult = false;
       jest.runAllTimers();
       expect(spy).toBeCalledTimes(6);
-      subscription.forEach(s => s.unsubscribe());
+      subscription.forEach((s) => s.unsubscribe());
     });
 
     it('should return false for hasHead()', () => {
@@ -654,7 +654,7 @@ describe('DirtyCheckEntity', () => {
 function deepEqual(x, y) {
   return x && y && typeof x === 'object' && typeof y === 'object'
     ? Object.keys(x).length === Object.keys(y).length &&
-        Object.keys(x).reduce(function(isEqual, key) {
+        Object.keys(x).reduce(function (isEqual, key) {
           return isEqual && deepEqual(x[key], y[key]);
         }, true)
     : x === y;

--- a/libs/akita/src/lib/plugins/dirtyCheck/dirtyCheckPlugin.ts
+++ b/libs/akita/src/lib/plugins/dirtyCheck/dirtyCheckPlugin.ts
@@ -18,7 +18,7 @@ export type DirtyCheckParams<StoreState = any> = {
 };
 
 export const dirtyCheckDefaultParams = {
-  comparator: (head, current) => JSON.stringify(head) !== JSON.stringify(current)
+  comparator: (head, current) => JSON.stringify(head) !== JSON.stringify(current),
 };
 
 export function getNestedPath(nestedObj, path: string) {
@@ -44,7 +44,7 @@ export class DirtyCheckPlugin<State = any> extends AkitaPlugin<State> {
     super(query);
     this.params = { ...dirtyCheckDefaultParams, ...params };
     if (this.params.watchProperty) {
-      let watchProp = coerceArray(this.params.watchProperty) as any[];
+      const watchProp = coerceArray(this.params.watchProperty) as any[];
       if (query instanceof QueryEntity && watchProp.includes('entities') && !watchProp.includes('ids')) {
         watchProp.push('ids');
       }
@@ -52,7 +52,7 @@ export class DirtyCheckPlugin<State = any> extends AkitaPlugin<State> {
     }
   }
 
-  reset(params: DirtyCheckResetParams = {}) {
+  reset(params: DirtyCheckResetParams = {}): void {
     let currentValue = this.head;
     if (isFunction(params.updateFn)) {
       if (this.isEntityBased(this._entityId)) {
@@ -66,7 +66,7 @@ export class DirtyCheckPlugin<State = any> extends AkitaPlugin<State> {
     this._reset.next();
   }
 
-  setHead() {
+  setHead(): DirtyCheckPlugin<State> {
     if (!this.active) {
       this.activate();
       this.active = true;
@@ -81,17 +81,17 @@ export class DirtyCheckPlugin<State = any> extends AkitaPlugin<State> {
     return !!this.dirty.value;
   }
 
-  hasHead() {
+  hasHead(): boolean {
     return !!this.getHead();
   }
 
-  destroy() {
+  destroy(): void {
     this.head = null;
     this.subscription && this.subscription.unsubscribe();
     this._reset && this._reset.complete();
   }
 
-  isPathDirty(path: string) {
+  isPathDirty(path: string): boolean {
     const head = this.getHead();
     const current = (this.getQuery() as Query<State>).getValue();
     const currentPathValue = getNestedPath(current, path);
@@ -100,7 +100,7 @@ export class DirtyCheckPlugin<State = any> extends AkitaPlugin<State> {
     return this.params.comparator(currentPathValue, headPathValue);
   }
 
-  protected getHead() {
+  getHead(): Partial<State> | State | undefined | null {
     return this.head;
   }
 
@@ -108,13 +108,13 @@ export class DirtyCheckPlugin<State = any> extends AkitaPlugin<State> {
     this.head = this._getHead();
     /** if we are tracking specific properties select only the relevant ones */
     const source = this.params.watchProperty
-      ? (this.params.watchProperty as (keyof State)[]).map(prop =>
+      ? (this.params.watchProperty as (keyof State)[]).map((prop) =>
           this.query
-            .select(state => state[prop])
+            .select((state) => state[prop])
             .pipe(
-              map(val => ({
+              map((val) => ({
                 val,
-                __akitaKey: prop
+                __akitaKey: prop,
               }))
             )
         )
@@ -124,7 +124,7 @@ export class DirtyCheckPlugin<State = any> extends AkitaPlugin<State> {
       .subscribe((currentState: any[]) => {
         if (isUndefined(this.head)) return;
         /** __akitaKey is used to determine if we are tracking a specific property or a store change */
-        const isChange = currentState.some(state => {
+        const isChange = currentState.some((state) => {
           const head = state.__akitaKey ? this.head[state.__akitaKey as any] : this.head;
           const compareTo = state.__akitaKey ? state.val : state;
 
@@ -148,12 +148,9 @@ export class DirtyCheckPlugin<State = any> extends AkitaPlugin<State> {
   }
 
   private getWatchedValues(source: State): Partial<State> {
-    return (this.params.watchProperty as (keyof State)[]).reduce(
-      (watched, prop) => {
-        watched[prop] = source[prop];
-        return watched;
-      },
-      {} as Partial<State>
-    );
+    return (this.params.watchProperty as (keyof State)[]).reduce((watched, prop) => {
+      watched[prop] = source[prop];
+      return watched;
+    }, {} as Partial<State>);
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

DirtyCheck getHead() is protected.

Issue Number: #593 

## What is the new behavior?

DirtyCheck getHead() is now public.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Other changed were introduced by Prettier. Fixed some small linting issues too.
