### PR TITLE
fix: 🐛 change the update method in the StateHistoryPlugin

### DIFF
--- a/libs/akita/src/__tests__/stateHistory.spec.ts
+++ b/libs/akita/src/__tests__/stateHistory.spec.ts
@@ -215,6 +215,38 @@ describe('StateHistory', () => {
       future: [],
     });
   });
+
+  it('should replace store on undo/redo', () => {
+    const stateHistory1 = new StateHistoryPlugin(query);
+
+    expect(stateHistory1.history).toEqual({
+      past: [],
+      present: { counter: 5 },
+      future: [],
+    });
+    expect(store.getValue()).toEqual({ counter: 5 });
+
+    store._setState((state) => ({
+      ...state,
+      newProperty: true,
+    }));
+
+    expect(stateHistory1.history).toEqual({
+      past: [{ counter: 5 }],
+      present: { counter: 5, newProperty: true },
+      future: [],
+    });
+    expect(store.getValue()).toEqual({ counter: 5, newProperty: true });
+
+    stateHistory1.undo();
+
+    expect(stateHistory1.history).toEqual({
+      past: [],
+      present: { counter: 5 },
+      future: [{ counter: 5, newProperty: true }],
+    });
+    expect(store.getValue()).toEqual({ counter: 5 });
+  });
 });
 
 const store2 = new CounterStore();

--- a/libs/akita/src/lib/entityStore.ts
+++ b/libs/akita/src/lib/entityStore.ts
@@ -362,10 +362,9 @@ export class EntityStore<S extends EntityState = any, EntityType = getEntityType
   replace(ids: IDS, newState: Partial<EntityType>) {
     const toArray = coerceArray(ids);
     if (isEmpty(toArray)) return;
-    let replaced = {};
+    const replaced = {};
     for (const id of toArray) {
-      newState[this.idKey] = id;
-      replaced[id] = newState;
+      replaced[id] = { ...newState, [this.idKey]: id };
     }
     isDev() && setAction('Replace Entity', ids);
     this._setState((state) => ({

--- a/libs/akita/src/lib/plugins/plugin.ts
+++ b/libs/akita/src/lib/plugins/plugin.ts
@@ -1,3 +1,4 @@
+import { EntityStore } from '../entityStore';
 import { QueryEntity } from '../queryEntity';
 import { Query } from '../query';
 import { filterNil } from '../filterNil';
@@ -42,7 +43,7 @@ export abstract class AkitaPlugin<State = any> {
     }
 
     if (property) {
-      return this.getQuery().select(state => getValue(state, this.withStoreName(property)));
+      return this.getQuery().select((state) => getValue(state, this.withStoreName(property)));
     }
 
     return this.getQuery().select();
@@ -71,17 +72,23 @@ export abstract class AkitaPlugin<State = any> {
   }
 
   /** This method is responsible for updating the store or one entity; it can be the whole store or one entity. */
-  protected updateStore(newState, entityId?, property?: string) {
+  protected updateStore(newState, entityId?, property?: string, replace = false) {
     if (this.isEntityBased(entityId)) {
-      this.getStore().update(entityId, newState);
+      const store = this.getStore() as EntityStore;
+
+      replace ? store.replace(entityId, newState) : store.update(entityId, newState);
     } else {
       if (property) {
-        this.getStore()._setState(state => {
-          return setValue(state, this.withStoreName(property), newState);
+        this.getStore()._setState((state) => {
+          return setValue(state, this.withStoreName(property), newState, true);
         });
+
         return;
       }
-      this.getStore()._setState(state => ({ ...state, ...newState }));
+
+      const nextState = replace ? newState : (state) => ({ ...state, ...newState });
+
+      this.getStore()._setState(nextState);
     }
   }
 

--- a/libs/akita/src/lib/plugins/stateHistory/stateHistoryPlugin.ts
+++ b/libs/akita/src/lib/plugins/stateHistory/stateHistoryPlugin.ts
@@ -23,7 +23,7 @@ export class StateHistoryPlugin<State = any> extends AkitaPlugin<State> {
   private history = {
     past: [],
     present: null,
-    future: []
+    future: [],
   };
 
   /** Skip the update when redo/undo */
@@ -38,7 +38,7 @@ export class StateHistoryPlugin<State = any> extends AkitaPlugin<State> {
 
   constructor(protected query: Queries<State>, private params: StateHistoryParams = {}, private _entityId?: any) {
     super(query, {
-      resetFn: () => this.clear()
+      resetFn: () => this.clear(),
     });
     params.maxAge = !!params.maxAge ? params.maxAge : 10;
     params.comparator = params.comparator || (() => true);
@@ -216,7 +216,7 @@ export class StateHistoryPlugin<State = any> extends AkitaPlugin<State> {
       : {
           past: [],
           present: null,
-          future: []
+          future: [],
         };
     this.updateHasHistory();
   }
@@ -235,7 +235,7 @@ export class StateHistoryPlugin<State = any> extends AkitaPlugin<State> {
   private update(action = 'Undo') {
     this.skipUpdate = true;
     logAction(`@StateHistory - ${action}`);
-    this.updateStore(this.history.present, this._entityId, this.property);
+    this.updateStore(this.history.present, this._entityId, this.property, true);
     this.updateHasHistory();
     this.skipUpdate = false;
   }

--- a/libs/akita/src/lib/setValueByString.ts
+++ b/libs/akita/src/lib/setValueByString.ts
@@ -6,7 +6,7 @@ import { isObject } from './isObject';
  * @example
  * setValue(state, 'todos.ui', { filter: {} })
  */
-export function setValue(obj: any, prop: string, val: any) {
+export function setValue(obj: any, prop: string, val: any, replace = false) {
   const split = prop.split('.');
 
   if (split.length === 1) {
@@ -24,7 +24,7 @@ export function setValue(obj: any, prop: string, val: any) {
       return acc && acc[part];
     }
 
-    acc[part] = Array.isArray(acc[part]) || !isObject(acc[part]) ? val : { ...acc[part], ...val };
+    acc[part] = replace || Array.isArray(acc[part]) || !isObject(acc[part]) ? val : { ...acc[part], ...val };
 
     return acc && acc[part];
   }, obj);


### PR DESCRIPTION
instead of updating state we should be replacing it

✅ Closes: #619

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

On undo/redo a store is being updated (merged), not replaced.

Issue Number: #619 

## What is the new behavior?

On undo/redo a store is being replaced.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I had to update the `EntityStore`'s `replace` method because of getting an error, something like:
> Cannot assign to 'id' because it is a read-only property