### PR TITLE
fix: filterNil removes undefined from resulting types in strict mode

### DIFF
--- a/docs/docs/additional/operators.mdx
+++ b/docs/docs/additional/operators.mdx
@@ -2,13 +2,13 @@
 title: Custom Operators
 ---
 
-### `filterNil`
+### `filterNilValue`
 Filters `undefined` or `null` values:
 
 ```ts
-import { filterNil } from '@datorama/akita';
+import { filterNilValue } from '@datorama/akita';
 
-query.selectEntity(1).pipe(filterNil).subscribe();
+query.selectEntity(1).pipe(filterNilValue()).subscribe();
 ```
 
 ### `setLoading`

--- a/libs/akita-ng-router-store/src/lib/router.query.ts
+++ b/libs/akita-ng-router-store/src/lib/router.query.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { filterNil, Query } from '@datorama/akita';
+import { filterNilValue, Query } from '@datorama/akita';
 import { combineLatest, Observable, Subject } from 'rxjs';
 import { distinctUntilChanged, map, pluck } from 'rxjs/operators';
 import { RouterState, RouterStore } from './router.store';
@@ -7,7 +7,7 @@ import { RouterState, RouterStore } from './router.store';
 function slice(section: string) {
   return (source: Observable<RouterState>) => {
     return source.pipe(map((data) => data.state)).pipe(
-      filterNil,
+      filterNilValue(),
       map((state) => state[section])
     );
   };

--- a/libs/akita/src/lib/filterNil.ts
+++ b/libs/akita/src/lib/filterNil.ts
@@ -1,10 +1,20 @@
-import { Observable } from 'rxjs';
+import { Observable, of, OperatorFunction } from 'rxjs';
 import { filter } from 'rxjs/operators';
-import { Diff } from './types';
 
 /**
  * @example
  *
  * query.selectEntity(2).pipe(filterNil)
+ * @deprecated Use the operator function filterNilValue()
  */
-export const filterNil = <T>(source: Observable<T | undefined | null>) => source.pipe(filter((value): value is Diff<T, null | undefined> => value !== null && typeof value !== 'undefined'));
+export const filterNil = <T>(source: Observable<T | undefined | null>): Observable<NonNullable<T>> =>
+  source.pipe(filter((value): value is NonNullable<T> => value !== null && typeof value !== 'undefined'));
+
+/**
+ * @example
+ *
+ * query.selectEntity(2).pipe(filterNilValue())
+ */
+export function filterNilValue<T>(): OperatorFunction<T, NonNullable<T>> {
+  return filter((value: T): value is NonNullable<T> => value !== null && value !== undefined);
+}

--- a/libs/akita/src/lib/index.ts
+++ b/libs/akita/src/lib/index.ts
@@ -4,7 +4,7 @@ export { QueryEntity, EntityUIQuery } from './queryEntity';
 export { Query } from './query';
 export { Store } from './store';
 export { applyTransaction, transaction, commit, endBatch, isTransactionInProcess, startBatch, TransactionManager, transactionManager, withTransaction } from './transaction';
-export { filterNil } from './filterNil';
+export { filterNil, filterNilValue } from './filterNil';
 export { DEFAULT_ID_KEY } from './defaultIDKey';
 export { action, setAction, setSkipAction, logAction, currentAction, resetCustomAction } from './actions';
 export { SnapshotManager, snapshotManager } from './snapshotManager';

--- a/libs/akita/src/lib/plugins/plugin.ts
+++ b/libs/akita/src/lib/plugins/plugin.ts
@@ -1,7 +1,7 @@
 import { EntityStore } from '../entityStore';
 import { QueryEntity } from '../queryEntity';
 import { Query } from '../query';
-import { filterNil } from '../filterNil';
+import { filterNilValue } from '../filterNil';
 import { toBoolean } from '../toBoolean';
 import { getAkitaConfig } from '../config';
 import { getValue } from '../getValueByString';
@@ -39,7 +39,7 @@ export abstract class AkitaPlugin<State = any> {
   /** This method is responsible for selecting the source; it can be the whole store or one entity. */
   protected selectSource(entityId: any, property?: string) {
     if (this.isEntityBased(entityId)) {
-      return (this.getQuery() as QueryEntity<State>).selectEntity(entityId).pipe(filterNil);
+      return (this.getQuery() as QueryEntity<State>).selectEntity(entityId).pipe(filterNilValue());
     }
 
     if (property) {

--- a/libs/akita/src/lib/types.ts
+++ b/libs/akita/src/lib/types.ts
@@ -59,4 +59,3 @@ export type getQueryEntityState<T extends QueryEntity<any>> = T extends QueryEnt
 
 export type ArrayFuncs = ((...a: any[]) => any)[];
 export type ReturnTypes<T extends ArrayFuncs> = { [P in keyof T]: T[P] extends (...a: any[]) => infer R ? R : never };
-export type Diff<T, U> = T extends U ? never : T;


### PR DESCRIPTION
Closes #606

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
In strict mode, filterNil fails to remove undefined from the input type.

Issue Number: 606

## What is the new behavior?
filterNil correctly removes undefined from the input type.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
