### PR TITLE
feat(store): add set method to akita store

### DIFF
--- a/docs/docs/store.mdx
+++ b/docs/docs/store.mdx
@@ -37,13 +37,13 @@ When you want to update the store, you can call the `update()` method passing th
 
 ```ts title="session.service.ts"
 import { SessionStore } from './session.store';
- 
+
 export class SessionService {
   constructor(private sessionStore: SessionStore) {}
 
   updateUserName(newName: string) {
     this.sessionStore.update({ name: newName });
-  }  
+  }
 }
 ```
 
@@ -51,7 +51,7 @@ The second `update()` option gives you more control. It receives a `callback` fu
 
 ```ts title="session.service.ts"
 import { SessionStore } from './session.store';
- 
+
 export class SessionService {
   constructor(private sessionStore: SessionStore) {}
 
@@ -59,18 +59,104 @@ export class SessionService {
     this.sessionStore.update(state => ({
       name: newName
     }));
-  }  
+  }
 }
 ```
+
+### `set()`
+
+When you don't just want to update the current store state but replace the state completely, you can call the `set()` method passing the new `state`:
+
+```ts title="session.service.ts"
+import { SessionStore } from './session.store';
+
+export class SessionService {
+  constructor(private sessionStore: SessionStore) {}
+
+  updateUserName(newName: string) {
+    this.sessionStore.set({ name: newName });
+  }
+}
+```
+
+As with `update()` the `set()` method also has a second option which gives you more control. It receives a `callback` function, which gets the current state, and returns a new **immutable** state, which will be the new value of the store. For example:
+
+```ts title="session.service.ts"
+import { SessionStore } from './session.store';
+
+export class SessionService {
+  constructor(private sessionStore: SessionStore) {}
+
+  updateUserName(newName: string) {
+    this.sessionStore.set(state => ({
+      name: newName
+    }));
+  }
+}
+```
+
+You should use `set()` over `update()` when you want to completely replace the current state at the top level.
+
+```ts title="session.store.ts"
+type SessionState = SessionStateAuthenticated | SessionStateUnauthenticated;
+
+interface SessionStateAuthenticated {
+  _tag: 'session-state-authenticated';
+  user: User;
+}
+
+interface SessionStateUnauthenticated {
+  _tag: 'session-state-unauthenticated'
+}
+
+interface User {
+  uid: string;
+  displayName: string;
+}
+
+```
+
+```json "current state"
+{
+  "_tag": "session-state-authenticated",
+  "user": {
+    "uid": "123",
+    "displayName": "John Doe"
+  }
+}
+```
+
+Using the above state model and value of current state, if we call `this.store.update({ _tag: 'session-state-unauthenticated' })` our state will be updated to the following:
+
+```json "using the update() method"
+{
+  "_tag": "session-state-unauthenticated",
+  "user": {
+    "uid": "123",
+    "displayName": "John Doe"
+  }
+}
+```
+
+Our value for tag has been updated but the user value from our previous state has stayed, this could lead to unintended side effects so in this case `this.store.set({ _tag: 'session-state-unauthenticated' })` may be a better option. When we use the `set()` method the following is the result:
+
+```json "using the update() method"
+{
+  "_tag": "session-state-unauthenticated",
+}
+```
+
+We have replaced the previous state completely, leaving behind no unexpected state values.
+
 
 ### `setLoading()`
 
 Set the `loading` state:
 ```ts title="session.service.ts"
 import { SessionStore } from './session.store';
- 
+
 export class SessionService {
-  constructor(private sessionStore: SessionStore, 
+  constructor(private sessionStore: SessionStore,
               private http: HttpClient) {}
 
   async updateUserName(newName: string) {
@@ -78,7 +164,7 @@ export class SessionService {
     await this.http(...).toPromise();
     this.sessionStore.update({ name: newName});
     this.sessionStore.setLoading(false);
-  }  
+  }
 }
 ```
 
@@ -87,9 +173,9 @@ Set the `error` state:
 
 ```ts title="session.service.ts"
 import { SessionStore } from './session.store';
- 
+
 export class SessionService {
-  constructor(private sessionStore: SessionStore, 
+  constructor(private sessionStore: SessionStore,
               private http: HttpClient) {}
 
   async updateUserName(newName: string) {
@@ -98,7 +184,7 @@ export class SessionService {
     } catch(error) {
       this.sessionStore.setError(error);
     }
-  }  
+  }
 }
 ```
 

--- a/libs/akita/src/__tests__/set.spec.ts
+++ b/libs/akita/src/__tests__/set.spec.ts
@@ -1,0 +1,54 @@
+import { Store, StoreConfig } from '@datorama/akita';
+
+type ExampleState = ExampleStateA | ExampleStateB;
+
+interface ExampleStateA {
+  _tag: 'a';
+  uniqueToA: string;
+}
+
+interface ExampleStateB {
+  _tag: 'b';
+  uniqueToB: string;
+}
+
+const initialState: ExampleState = {
+  _tag: 'a',
+  uniqueToA: 'This value is unique to a',
+};
+
+@StoreConfig({
+  name: 'example-store',
+  resettable: true,
+})
+class ExampleStore extends Store<ExampleState> {
+  constructor() {
+    super(initialState);
+  }
+}
+
+const exampleStore = new ExampleStore();
+
+describe('Store Set', () => {
+  beforeEach(() => {
+    exampleStore.reset();
+  });
+
+  it('should set the store value replacing the previous state using a state object', () => {
+    exampleStore.set({ _tag: 'b', uniqueToB: 'This value is unique to b' });
+    expect(exampleStore._value()).toBeTruthy();
+    expect(exampleStore._value()).toEqual({_tag: 'b', uniqueToB: 'This value is unique to b'});
+  });
+
+  it('should set the store value replacing the previous state using a callback function', () => {
+    exampleStore.set((_) => ({ _tag: 'b', uniqueToB: 'This value is unique to b' }));
+    expect(exampleStore._value()).toBeTruthy();
+    expect(exampleStore._value()).toEqual({_tag: 'b', uniqueToB: 'This value is unique to b'});
+  });
+
+  it('should update the store value but only replace specified properties', () => {
+    exampleStore.update({ _tag: 'b', uniqueToB: 'This value is unique to b' });
+    expect(exampleStore._value()).toBeTruthy();
+    expect(exampleStore._value()).toEqual({_tag: 'b', uniqueToB: 'This value is unique to b', uniqueToA: 'This value is unique to a'});
+  });
+});


### PR DESCRIPTION
Created a public method on the akita store that will completely replace the current state with the new provided state and not just update the value.

Closes #661

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ x ] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [ x ] Tests for the changes have been added (for bug fixes / features)
- [ x ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #661

## What is the new behavior?

When the `set()` method is used the current state of the store will be replaced not just { ...currentState, ...newState } merged together.

See issue #661 for more details.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
