### PR TITLE
fix(akita): restrict usage of sortByOrder to valid usages in type system

### DIFF
--- a/libs/akita/src/lib/queryConfig.ts
+++ b/libs/akita/src/lib/queryConfig.ts
@@ -1,13 +1,22 @@
 import { Order } from './sort';
 
-export type SortBy<E, S = any> = ((a: E, b: E, state?: S) => number) | keyof E;
+type SortByFunction<E, S = any> = (a: E, b: E, state?: S) => number;
+type SortByKey<E> = keyof E;
+export type SortBy<E, S = any> = SortByFunction<E, S> | SortByKey<E>;
 
-export interface SortByOptions<E> {
-  sortBy?: SortBy<E>;
+interface SortByFunctionOptions<E> {
+  sortBy?: SortByFunction<E>;
+  sortByOrder?: undefined;
+}
+
+interface SortByKeyOptions<E> {
+  sortBy?: SortByKey<E>;
   sortByOrder?: Order;
 }
 
-export interface QueryConfigOptions<E = any> extends SortByOptions<E> {}
+export type SortByOptions<E> = SortByFunctionOptions<E> | SortByKeyOptions<E>;
+
+export type QueryConfigOptions<E = any> = SortByOptions<E>;
 
 export const queryConfigKey = 'akitaQueryConfig';
 

--- a/libs/akita/src/lib/selectAllOverloads.ts
+++ b/libs/akita/src/lib/selectAllOverloads.ts
@@ -1,9 +1,8 @@
 import { SelectOptions } from './types';
-import { SortBy } from './queryConfig';
-import { Order } from './sort';
+import { SortByOptions } from './queryConfig';
 
 export type SelectAllOptionsA<E> = { asObject: true; filterBy?: SelectOptions<E>['filterBy']; limitTo?: number; sortBy?: undefined; sortByOrder?: undefined };
-export type SelectAllOptionsB<E> = { filterBy: SelectOptions<E>['filterBy']; limitTo?: number; sortBy?: SortBy<E>; sortByOrder?: Order };
+export type SelectAllOptionsB<E> = { filterBy: SelectOptions<E>['filterBy']; limitTo?: number; } & SortByOptions<E>
 export type SelectAllOptionsC<E> = { asObject: true; limitTo?: number; sortBy?: undefined; sortByOrder?: undefined };
-export type SelectAllOptionsD<E> = { limitTo?: number; sortBy?: SortBy<E>; sortByOrder?: Order };
-export type SelectAllOptionsE<E> = { asObject: false; filterBy?: SelectOptions<E>['filterBy']; limitTo?: number; sortBy?: SortBy<E>; sortByOrder?: Order };
+export type SelectAllOptionsD<E> = { limitTo?: number; } & SortByOptions<E>
+export type SelectAllOptionsE<E> = { asObject: false; filterBy?: SelectOptions<E>['filterBy']; limitTo?: number; } & SortByOptions<E>

--- a/libs/akita/src/lib/types.ts
+++ b/libs/akita/src/lib/types.ts
@@ -27,7 +27,7 @@ export interface MultiActiveState<T = ID> {
   active: T[];
 }
 
-export interface SelectOptions<E> extends SortByOptions<E> {
+export type SelectOptions<E> = SortByOptions<E> & {
   asObject?: boolean;
   filterBy?: ((entity: E, index?: number) => boolean) | ((entity: E, index?: number) => boolean)[] | undefined;
   limitTo?: number;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

When using `getAll` or `selectAll` from a `QueryEntity` and providing a `sortBy` function, the `sortByOrder` is ignored. This is not represented in the type system and therefore lead to some initial confusion in our team.

Issue Number: N/A

## What is the new behavior?

`sortByOrder` can no longer be provided when providing a `sortBy` function. This is now restricted by the type system.
![image](https://user-images.githubusercontent.com/6975408/116592918-d73bcc00-a920-11eb-9201-0ae56967b733.png)

`sortByOrder` can can still be provided when providing a `sortBy` field.
![image](https://user-images.githubusercontent.com/6975408/116592786-ae1b3b80-a920-11eb-9768-8ff7c620c12b.png)

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

Projects that provided a `sortByOrder` and a `sortBy` function will have a failing build and need to remove the `sortByOrder`

## Other information
