### PR TITLE
fix(akita-ng-entity-service): loader late subscriber

### DIFF
--- a/docs/docs/angular/entity-service.mdx
+++ b/docs/docs/angular/entity-service.mdx
@@ -242,7 +242,8 @@ The global `config` provide takes the following object:
       baseUrl: 'https://jsonplaceholder.typicode.com',
       httpMethods: {
         PUT: HttpMethod.PATCH
-      }
+      },
+      connector: () => new ReplaySubject(1),
     } as NgEntityServiceGlobalConfig;
   }
 }

--- a/libs/akita-ng-entity-service/src/lib/ng-entity-service.config.ts
+++ b/libs/akita-ng-entity-service/src/lib/ng-entity-service.config.ts
@@ -1,6 +1,7 @@
 import { InjectionToken } from '@angular/core';
 import { NgEntityServiceParams } from './types';
 import { HttpMethod } from './ng-entity-service-notifier';
+import { Event } from './ng-entity-service.loader';
 import { isObject } from '@datorama/akita';
 import { Subject } from 'rxjs';
 
@@ -13,7 +14,7 @@ export interface NgEntityServiceGlobalConfig {
     PUT: HttpMethod;
     DELETE: HttpMethod;
   }>;
-  connector?: () => Subject<{ method: HttpMethod; loading: boolean; storeName: string; entityId?: any }>;
+  connector?: () => Subject<Event>;
 }
 
 export const NG_ENTITY_SERVICE_CONFIG = new InjectionToken<NgEntityServiceGlobalConfig>('NgEntityServiceGlobalConfig');

--- a/libs/akita-ng-entity-service/src/lib/ng-entity-service.config.ts
+++ b/libs/akita-ng-entity-service/src/lib/ng-entity-service.config.ts
@@ -12,6 +12,7 @@ export interface NgEntityServiceGlobalConfig {
     PUT: HttpMethod;
     DELETE: HttpMethod;
   }>;
+  replayLoader?: boolean;
 }
 
 export const NG_ENTITY_SERVICE_CONFIG = new InjectionToken<NgEntityServiceGlobalConfig>('NgEntityServiceGlobalConfig');
@@ -22,8 +23,8 @@ export const defaultConfig: NgEntityServiceGlobalConfig = {
     POST: HttpMethod.POST,
     PATCH: HttpMethod.PATCH,
     PUT: HttpMethod.PUT,
-    DELETE: HttpMethod.DELETE
-  }
+    DELETE: HttpMethod.DELETE,
+  },
 };
 
 export function mergeDeep(target, ...sources) {
@@ -45,7 +46,7 @@ export function mergeDeep(target, ...sources) {
 }
 
 export function NgEntityServiceConfig(config: NgEntityServiceParams = {}) {
-  return function(constructor) {
+  return function (constructor) {
     if (config.baseUrl) {
       constructor['baseUrl'] = config.baseUrl;
     }

--- a/libs/akita-ng-entity-service/src/lib/ng-entity-service.config.ts
+++ b/libs/akita-ng-entity-service/src/lib/ng-entity-service.config.ts
@@ -2,6 +2,7 @@ import { InjectionToken } from '@angular/core';
 import { NgEntityServiceParams } from './types';
 import { HttpMethod } from './ng-entity-service-notifier';
 import { isObject } from '@datorama/akita';
+import { Subject } from 'rxjs';
 
 export interface NgEntityServiceGlobalConfig {
   baseUrl?: string;
@@ -12,7 +13,7 @@ export interface NgEntityServiceGlobalConfig {
     PUT: HttpMethod;
     DELETE: HttpMethod;
   }>;
-  replayLoader?: boolean;
+  connector?: () => Subject<{ method: HttpMethod; loading: boolean; storeName: string; entityId?: any }>;
 }
 
 export const NG_ENTITY_SERVICE_CONFIG = new InjectionToken<NgEntityServiceGlobalConfig>('NgEntityServiceGlobalConfig');

--- a/libs/akita-ng-entity-service/src/lib/ng-entity-service.loader.ts
+++ b/libs/akita-ng-entity-service/src/lib/ng-entity-service.loader.ts
@@ -1,15 +1,15 @@
-import { ReplaySubject, Subject } from 'rxjs';
+import { Subject } from 'rxjs';
 import { inject, Injectable } from '@angular/core';
 import { filter, map } from 'rxjs/operators';
 import { isFunction } from '@datorama/akita';
 import { HttpMethod } from './ng-entity-service-notifier';
-import { NG_ENTITY_SERVICE_CONFIG } from '@datorama/akita-ng-entity-service';
+import { NG_ENTITY_SERVICE_CONFIG, NgEntityServiceGlobalConfig } from '@datorama/akita-ng-entity-service';
 
 type Event = { method: HttpMethod; loading: boolean; storeName: string; entityId?: any };
 
 @Injectable({ providedIn: 'root' })
 export class NgEntityServiceLoader {
-  private dispatcher = inject(NG_ENTITY_SERVICE_CONFIG)?.replayLoader ? new ReplaySubject<Event>() : new Subject<Event>();
+  private dispatcher = this.config.connector ? this.config.connector() : new Subject<Event>();
   loading$ = this.dispatcher.asObservable();
 
   dispatch(event: Event) {
@@ -47,5 +47,9 @@ export class NgEntityServiceLoader {
       updateEntity: (id: any) => idBased(id, (method) => method === HttpMethod.PUT || method === HttpMethod.PATCH),
       deleteEntity: (id: any) => idBased(id, HttpMethod.DELETE),
     };
+  }
+
+  get config(): NgEntityServiceGlobalConfig {
+    return inject(NG_ENTITY_SERVICE_CONFIG);
   }
 }

--- a/libs/akita-ng-entity-service/src/lib/ng-entity-service.loader.ts
+++ b/libs/akita-ng-entity-service/src/lib/ng-entity-service.loader.ts
@@ -1,14 +1,15 @@
-import { Subject } from 'rxjs';
-import { Injectable } from '@angular/core';
+import { ReplaySubject, Subject } from 'rxjs';
+import { inject, Injectable } from '@angular/core';
 import { filter, map } from 'rxjs/operators';
 import { isFunction } from '@datorama/akita';
 import { HttpMethod } from './ng-entity-service-notifier';
+import { NG_ENTITY_SERVICE_CONFIG } from '@datorama/akita-ng-entity-service';
 
 type Event = { method: HttpMethod; loading: boolean; storeName: string; entityId?: any };
 
 @Injectable({ providedIn: 'root' })
 export class NgEntityServiceLoader {
-  private dispatcher = new Subject<Event>();
+  private dispatcher = inject(NG_ENTITY_SERVICE_CONFIG)?.replayLoader ? new ReplaySubject<Event>() : new Subject<Event>();
   loading$ = this.dispatcher.asObservable();
 
   dispatch(event: Event) {
@@ -17,7 +18,7 @@ export class NgEntityServiceLoader {
 
   loadersFor(name?: string) {
     const filterStore = filter(({ storeName }: Event) => (name ? storeName === name : true));
-    const filterMethod = mthd =>
+    const filterMethod = (mthd) =>
       filter(({ method }: Event) => {
         return isFunction(mthd) ? mthd(method) : method === mthd;
       });
@@ -26,25 +27,25 @@ export class NgEntityServiceLoader {
       this.loading$.pipe(
         filterStore,
         filterMethod(current),
-        map(action => action.loading)
+        map((action) => action.loading)
       );
 
     const idBased = (id: any, mthd: ((method) => boolean) | HttpMethod) =>
       this.loading$.pipe(
         filterStore,
         filterMethod(mthd),
-        filter(action => action.entityId === id),
-        map(action => action.loading)
+        filter((action) => action.entityId === id),
+        map((action) => action.loading)
       );
 
     return {
       get$: actionBased(HttpMethod.GET),
       add$: actionBased(HttpMethod.POST),
-      update$: actionBased(method => method === HttpMethod.PUT || method === HttpMethod.PATCH),
+      update$: actionBased((method) => method === HttpMethod.PUT || method === HttpMethod.PATCH),
       delete$: actionBased(HttpMethod.DELETE),
       getEntity: (id: any) => idBased(id, HttpMethod.GET),
-      updateEntity: (id: any) => idBased(id, method => method === HttpMethod.PUT || method === HttpMethod.PATCH),
-      deleteEntity: (id: any) => idBased(id, HttpMethod.DELETE)
+      updateEntity: (id: any) => idBased(id, (method) => method === HttpMethod.PUT || method === HttpMethod.PATCH),
+      deleteEntity: (id: any) => idBased(id, HttpMethod.DELETE),
     };
   }
 }

--- a/libs/akita-ng-entity-service/src/lib/ng-entity-service.loader.ts
+++ b/libs/akita-ng-entity-service/src/lib/ng-entity-service.loader.ts
@@ -5,7 +5,7 @@ import { isFunction } from '@datorama/akita';
 import { HttpMethod } from './ng-entity-service-notifier';
 import { NG_ENTITY_SERVICE_CONFIG, NgEntityServiceGlobalConfig } from '@datorama/akita-ng-entity-service';
 
-type Event = { method: HttpMethod; loading: boolean; storeName: string; entityId?: any };
+export type Event = { method: HttpMethod; loading: boolean; storeName: string; entityId?: any };
 
 @Injectable({ providedIn: 'root' })
 export class NgEntityServiceLoader {

--- a/libs/akita-ng-entity-service/src/lib/ng-entity-service.spec.ts
+++ b/libs/akita-ng-entity-service/src/lib/ng-entity-service.spec.ts
@@ -277,7 +277,7 @@ describe('NgEntityService', () => {
           TestServiceWithInlineConfig,
           {
             provide: NG_ENTITY_SERVICE_CONFIG,
-            useValue: {} as NgEntityServiceGlobalConfig,
+            useValue: { replayLoader: true } as NgEntityServiceGlobalConfig,
           },
         ],
         imports: [HttpClientTestingModule],
@@ -688,6 +688,16 @@ describe('NgEntityService', () => {
         ]);
       })
     ));
+
+    it('should receive first truthy emission from late subscription given replay config', (done) => {
+      inject([TestServiceWithInlineConfig, HttpTestingController, NgEntityServiceLoader], (service: TestServiceWithInlineConfig, httpMock: HttpTestingController, loader: NgEntityServiceLoader) => {
+        service.get().subscribe();
+        loader.loadersFor(storeName).get$.subscribe((value) => {
+          expect(value).toEqual(true);
+          done();
+        });
+      })();
+    });
   });
 
   describe('add', () => {

--- a/libs/akita-ng-entity-service/src/lib/ng-entity-service.spec.ts
+++ b/libs/akita-ng-entity-service/src/lib/ng-entity-service.spec.ts
@@ -13,6 +13,7 @@ import {
   TestServiceWithMixedConfig,
   TestStore,
 } from './setup';
+import { ReplaySubject } from 'rxjs';
 
 describe('NgEntityService', () => {
   describe('should merge config in order...', () => {
@@ -277,7 +278,7 @@ describe('NgEntityService', () => {
           TestServiceWithInlineConfig,
           {
             provide: NG_ENTITY_SERVICE_CONFIG,
-            useValue: { replayLoader: true } as NgEntityServiceGlobalConfig,
+            useValue: { connector: () => new ReplaySubject(1) } as NgEntityServiceGlobalConfig,
           },
         ],
         imports: [HttpClientTestingModule],
@@ -689,7 +690,7 @@ describe('NgEntityService', () => {
       })
     ));
 
-    it('should receive first truthy emission from late subscription given replay config', (done) => {
+    it('should receive first truthy emission from late subscription given ReplaySubject connector', (done) => {
       inject([TestServiceWithInlineConfig, HttpTestingController, NgEntityServiceLoader], (service: TestServiceWithInlineConfig, httpMock: HttpTestingController, loader: NgEntityServiceLoader) => {
         service.get().subscribe();
         loader.loadersFor(storeName).get$.subscribe((value) => {


### PR DESCRIPTION
Added Configuration to enable NgEntityServiceLoader to utilize a ReplaySubject

fixes #668

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #668

## What is the new behavior?

An option to use a `ReplaySubject` over a `Subject` for the `NgEntityServiceLoader` dispatcher. This allows late subscribers (e.g. components that call `get()` via `ngOnInit` and subscribe to `get$` via async pipe in the template) to receive the latest emission on subscription.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
