### PR TITLE
combineQueries is not strongly typed

### DIFF
--- a/libs/akita/src/lib/combineQueries.ts
+++ b/libs/akita/src/lib/combineQueries.ts
@@ -1,9 +1,17 @@
 import { combineLatest, Observable, ObservableInput, ObservedValueOf } from 'rxjs';
 import { auditTime } from 'rxjs/operators';
 
-type ReturnTypes<T extends Observable<any>[]> = { [P in keyof T]: T[P] extends Observable<infer R> ? R : never };
-type Observables = [Observable<any>] | Observable<any>[];
+export function combineQueries<O1 extends ObservableInput<any>>(sources: [O1]): Observable<[ObservedValueOf<O1>]>;
+export function combineQueries<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>>(sources: [O1, O2]): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>]>;
+export function combineQueries<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>>(sources: [O1, O2, O3]): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>]>;
+export function combineQueries<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>>(sources: [O1, O2, O3, O4]): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>]>;
+export function combineQueries<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>>(sources: [O1, O2, O3, O4, O5]): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>, ObservedValueOf<O5>]>;
+export function combineQueries<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>, O6 extends ObservableInput<any>>(sources: [O1, O2, O3, O4, O5, O6]): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>, ObservedValueOf<O5>, ObservedValueOf<O6>]>;
+export function combineQueries<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>, O6 extends ObservableInput<any>, O7 extends ObservableInput<any>>(sources: [O1, O2, O3, O4, O5, O6, O7]): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>, ObservedValueOf<O5>, ObservedValueOf<O6>, ObservedValueOf<O7>]>;
+export function combineQueries<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>, O6 extends ObservableInput<any>, O7 extends ObservableInput<any>, O8 extends ObservableInput<any>>(sources: [O1, O2, O3, O4, O5, O6, O7, O8]): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>, ObservedValueOf<O5>, ObservedValueOf<O6>, ObservedValueOf<O7>, ObservedValueOf<O8>]>;
+export function combineQueries<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>, O6 extends ObservableInput<any>, O7 extends ObservableInput<any>, O8 extends ObservableInput<any>, O9 extends ObservableInput<any>>(sources: [O1, O2, O3, O4, O5, O6, O7, O8, O9]): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>, ObservedValueOf<O5>, ObservedValueOf<O6>, ObservedValueOf<O7>, ObservedValueOf<O8>, ObservedValueOf<O9>]>;
+export function combineQueries<O extends ObservableInput<any>>(sources: O[]): Observable<ObservedValueOf<O>[]>;
 
-export function combineQueries<R extends Observables>(observables: R): Observable<ReturnTypes<R>> {
-  return combineLatest(observables).pipe(auditTime(0)) as any;
+export function combineQueries<O extends ObservableInput<any>>(sources: O[]): Observable<ObservedValueOf<O>[]> {
+  return combineLatest([...sources]).pipe(auditTime(0));
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

combineQueries method is not providing types down to the pipe as combineLatest does

## What is the new behavior?

combineQueries now copies a signature of combineLatest method with the ability for typescript to calculate types down to the pipe

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
