### PR TITLE
fix: 🐛 correcting homepage links in package.json's

### DIFF
--- a/libs/akita-ng-effects/package.json
+++ b/libs/akita-ng-effects/package.json
@@ -17,7 +17,7 @@
     "reactive",
     "effects"
   ],
-  "homepage": "https://github.com/datorama/tree/master/libs/akita-ng-effects#readme",
+  "homepage": "https://github.com/datorama/akita/tree/master/libs/akita-ng-effects#readme",
   "bugs": {
     "url": "https://github.com/datorama/akita/issues"
   },

--- a/libs/akita/package.json
+++ b/libs/akita/package.json
@@ -16,7 +16,7 @@
     "redux",
     "reactive"
   ],
-  "homepage": "https://github.com/datorama/tree/master/libs/akita#readme",
+  "homepage": "https://github.com/datorama/akita/tree/master/libs/akita#readme",
   "bugs": {
     "url": "https://github.com/datorama/akita/issues"
   },


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [X] Other... Please describe:
Correcting the homepage links in package.json's

## What is the current behavior?

When on the page for [`@dataorama/akita`](https://www.npmjs.com/package/@datorama/akita) or [`@dataorama/akita-ng-effects`](https://www.npmjs.com/package/@datorama/akita-ng-effects) on npm and you click the "Homepage" link, it takes to a 404 not found as the link is missing the repository name. i.e. instead of github.com/datorama/akita/tree, it is github.com/dataorama/tree

Issue Number: N/A

## What is the new behavior?

Clicking the homepage links will take to the correct repository

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
