### PR TITLE
feat(akita): more typesafe EntityState

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -563,6 +563,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "RobinVdBroeck",
+      "name": "Robin Van den Broeck",
+      "avatar_url": "https://avatars.githubusercontent.com/u/3083785?v=4",
+      "profile": "https://robinvdb.me",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds
     <td align="center"><a href="https://github.com/talohana"><img src="https://avatars2.githubusercontent.com/u/24203431?v=4" width="100px;" alt=""/><br /><sub><b>Tal Ohana</b></sub></a><br /><a href="https://github.com/NetanelBasal/akita/commits?author=talohana" title="Code">💻</a></td>
     <td align="center"><a href="https://medium.com/@marcinmilewicz"><img src="https://avatars3.githubusercontent.com/u/40635984?v=4" width="100px;" alt=""/><br /><sub><b>Marcin Milewicz</b></sub></a><br /><a href="https://github.com/NetanelBasal/akita/commits?author=marcinmilewicz" title="Code">💻</a></td>
     <td align="center"><a href="https://medium.com/@erxk"><img src="https://avatars.githubusercontent.com/u/14320878?v=4" width="100px;" alt=""/><br /><sub><b>Erik</b></sub></a><br /><a href="https://github.com/NetanelBasal/akita/commits?author=Everduin94" title="Code">💻</a></td>
+    <td align="center"><a href="https://robinvdb.me"><img src="https://avatars.githubusercontent.com/u/3083785?v=4" width="100px;" alt=""/><br /><sub><b>Robin Van den Broeck</b></sub></a><br /><a href="https://github.com/NetanelBasal/akita/commits?author=RobinVdBroeck" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/libs/akita/src/__tests__/store.spec.ts
+++ b/libs/akita/src/__tests__/store.spec.ts
@@ -1,4 +1,4 @@
-import { EntityStore, Query, Store, StoreConfig } from '..';
+import { EntityStore, Query, Store, StoreConfig, EntityState } from '..';
 import { TodosStore } from './setup';
 
 interface State {
@@ -9,12 +9,12 @@ interface State {
 
 const state = {
   theme: {
-    color: 'red'
-  }
+    color: 'red',
+  },
 };
 
 @StoreConfig({
-  name: 'themes'
+  name: 'themes',
 })
 class ThemeStore extends Store<State> {
   constructor() {
@@ -31,7 +31,7 @@ describe('Store', () => {
 
   it('should select slice from the store', () => {
     const spy = jest.fn();
-    store._select(state => state.theme).subscribe(spy);
+    store._select((state) => state.theme).subscribe(spy);
     expect(spy).toHaveBeenCalledWith({ color: 'red' });
     expect(spy).toHaveBeenCalledTimes(1);
   });
@@ -46,13 +46,13 @@ describe('Store', () => {
 
   it('should set a new state', () => {
     const spy = jest.fn();
-    store._select(state => state.theme).subscribe(spy);
-    store._setState(state => {
+    store._select((state) => state.theme).subscribe(spy);
+    store._setState((state) => {
       return {
         ...state,
         theme: {
-          color: 'blue'
-        }
+          color: 'blue',
+        },
       };
     });
 
@@ -61,8 +61,8 @@ describe('Store', () => {
     expect(spy).toHaveBeenCalledTimes(2);
     expect(store._value()).toEqual({
       theme: {
-        color: 'blue'
-      }
+        color: 'blue',
+      },
     });
   });
 
@@ -103,7 +103,7 @@ class User {
 }
 
 @StoreConfig({
-  name: 'user'
+  name: 'user',
 })
 class UserStore extends Store<User> {
   constructor() {
@@ -127,7 +127,7 @@ describe('With Class', () => {
 });
 
 @StoreConfig({
-  name: 'user'
+  name: 'user',
 })
 class TestStore extends Store<User> {
   constructor() {
@@ -141,7 +141,7 @@ const testQuery = new Query(testStore);
 describe('Loading Basic Store', () => {
   it('should support loading', () => {
     let value;
-    testQuery.selectLoading().subscribe(v => {
+    testQuery.selectLoading().subscribe((v) => {
       value = v;
     });
     expect(value).toBeTruthy();
@@ -172,5 +172,24 @@ describe('StoreConfig', () => {
   it('should take from the constructor', () => {
     expect(productsStore2.storeName).toBe('pr');
     expect(productsStore2.idKey).toBe('id');
+  });
+});
+
+describe('Store with extented EntityState', () => {
+  type Todo = any;
+  interface TodosState extends EntityState<Todo, number> {
+    filter: string;
+  }
+
+  @StoreConfig({ name: 'todos' })
+  class TodosStore extends EntityStore<TodosState> {
+    constructor() {
+      super({ filter: 'ALL' });
+    }
+  }
+
+  it('should have the initial state', () => {
+    const store = new TodosStore();
+    expect(store.getValue().filter).toBe('ALL');
   });
 });

--- a/libs/akita/src/lib/types.ts
+++ b/libs/akita/src/lib/types.ts
@@ -11,7 +11,6 @@ export interface EntityState<E = any, IDType = any> {
   ids?: IDType[];
   loading?: boolean;
   error?: any;
-  [key: string]: any;
 }
 
 export interface Entities<E> {


### PR DESCRIPTION
This deletes the {[key: string]: any} from the definiton of EnityState.
This is breaking change, because users of akita might have failing
typechecking now. (However, this should have failed either way, since it
was not correct.)

See #744 for the reasoning behind this change.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [X] Other... Please describe: Typesafety

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #744

## What is the new behavior?

## Does this PR introduce a breaking change?

- [X] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
