### PR TITLE
fix: Explicit check for boolean value

### DIFF
--- a/libs/akita-ng-effects/src/__tests__/module-manager.service.spec.ts
+++ b/libs/akita-ng-effects/src/__tests__/module-manager.service.spec.ts
@@ -9,6 +9,7 @@ describe('Module Manager Service', () => {
   let mixedInstance;
   let mockEffectOne;
   let mockEffectTwo;
+  let truthyNoEffect;
   let noEffect;
   let actions$;
   let observable$;
@@ -17,6 +18,7 @@ describe('Module Manager Service', () => {
     actions$ = new Actions();
     mockEffectOne = Object.create(actions$);
     mockEffectTwo = Object.create(actions$);
+    truthyNoEffect = { isEffect: { test: 'test' }};
     setMetadata(mockEffectOne, 'mockEffectOne', {});
     setMetadata(mockEffectTwo, 'mockEffectTwo', {});
 
@@ -32,6 +34,7 @@ describe('Module Manager Service', () => {
     mixedInstance = {
       mockEffectOne,
       noEffect,
+      truthyNoEffect,
     };
   });
 

--- a/libs/akita-ng-effects/src/lib/module-manager.service.ts
+++ b/libs/akita-ng-effects/src/lib/module-manager.service.ts
@@ -16,7 +16,7 @@ export class ModuleManager implements OnDestroy {
   subscribeToEffects(effectInstance: Type<any>): void {
     for (let key in effectInstance) {
       const property: Effect = effectInstance[key];
-      if (property.isEffect) {
+      if (property.isEffect === true) {
         property.pipe(takeUntil(this.destroyEffects$)).subscribe((actionOrSkip) => {
           this.dispatchAction(property, actionOrSkip);
         });


### PR DESCRIPTION
akita-ng-effects: Had a situation where AngularFireAuth was a object of a custom Proxy type that when property.isEffect was called, it returned an object which evaluated as truthy passing the if statement before blowing up.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

When isEffect was called on a property that does not return undefined and instead returns something non boolean but truthy the if statement passes incorrectly. 

```
property.isEffect // in my case the call resolves to Proxy { length: 0, name: '' } which is truthy and passes the check
```

```
if (property.isEffect) {
  // blows up in here because it's not an effect.
});

```

Issue Number: N/A

## What is the new behavior?


changing to an explicit check for boolean true fixes the problem

```
if (property.isEffect === true) {
  // truthy object no longer reaches here.
});
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

