### PR TITLE
feat(akita): 🔥 add native middleware hooks binding support

### DIFF
--- a/docs/docs/additional/middleware.mdx
+++ b/docs/docs/additional/middleware.mdx
@@ -10,18 +10,18 @@ export class BooksStore extends EntityStore<BooksState> {
   constructor() {
     super();
   }
-  
+
   akitaPreAddEntity(book: Book) {
-    if(book.price === 100) {
+    if (book.price === 100) {
       return {
         ...book,
-        price: limitedPrice
-      }                    
+        price: limitedPrice,
+      };
     }
-  
+
     return book;
   }
-  
+
   akitaPreUpdateEntity(prevBook: Book, nextBook: Book) {
     // return the same entity or modify it
   }
@@ -32,7 +32,7 @@ The `preAddEntity()` middleware is called when we invoke the `EntityStore.set()`
 
 The `preUpdateEntity()` middleware is called with the previous entity’s data, as well as the updated version of it, whenever we call any `EntityStore` method that updates an entity, for instance, `EntityStore.update(1)` , `EntityStore.updateActive()`.
 
-In addition to that, we’ve added the `preUpdate()` middleware that’s supported in both stores, and is called with the previous and the current state. 
+In addition to that, we’ve added the `preUpdate()` middleware that’s supported in both stores, and is called with the previous and the current state.
 
 This middleware is called whenever we call `Store.update()`. For example:
 
@@ -42,7 +42,7 @@ export class AuthStore extends Store<AuthState> {
   constructor() {
     super();
   }
-  
+
   akitaPreUpdate(prevState: AuthState, nextState: AuthState) {
     // return the same state or modify it
   }
@@ -52,16 +52,16 @@ export class AuthStore extends Store<AuthState> {
 These can also be useful for debugging purposes. For example, logging who's updating the store.
 
 ## Using this
-In case you want to use the this context inside the hook, you need to use the `bind` function:
+
+You can just use `this` without worrying about it :)
 
 ```ts title="auth.store.ts"
 @StoreConfig({ name: 'auth' })
 export class AuthStore extends Store<AuthState> {
   constructor(private someService: SomeService) {
     super();
-    this.akitaPreUpdate = this.akitaPreUpdate.bind(this);
   }
-  
+
   akitaPreUpdate(prevState: AuthState, nextState: AuthState) {
     this.someService.getData();
     // return the same state or modify it

--- a/packages/akita/src/lib/entityStore.ts
+++ b/packages/akita/src/lib/entityStore.ts
@@ -99,7 +99,7 @@ export class EntityStore<S extends EntityState = any, EntityType = getEntityType
         state,
         entities,
         idKey: this.idKey,
-        preAddEntity: this.akitaPreAddEntity,
+        preAddEntity: this.akitaPreAddEntity.bind(this),
         isNativePreAdd,
       });
 
@@ -135,7 +135,7 @@ export class EntityStore<S extends EntityState = any, EntityType = getEntityType
 
     const data = addEntities({
       state: this._value(),
-      preAddEntity: this.akitaPreAddEntity,
+      preAddEntity: this.akitaPreAddEntity.bind(this),
       entities: collection,
       idKey: this.idKey,
       options,
@@ -214,7 +214,7 @@ export class EntityStore<S extends EntityState = any, EntityType = getEntityType
       updateEntities({
         idKey: this.idKey,
         ids,
-        preUpdateEntity: this.akitaPreUpdateEntity,
+        preUpdateEntity: this.akitaPreUpdateEntity.bind(this),
         state,
         newStateOrFn,
         producerFn: this._producerFn,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[z] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

currently there isn't any ability to use `this` in middleware hooks without doing a "binding trick" 

Issue Number: #782 

## What is the new behavior?

It adds `bind` to the entityStore middleware hooks

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
