### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/packages/akita-schematics/src/ng-g/utils/pluralize.ts
+++ b/packages/akita-schematics/src/ng-g/utils/pluralize.ts
@@ -55,7 +55,7 @@ declare const define: any;
 
     // Title cased words. E.g. "Title".
     if (word[0] === word[0].toUpperCase()) {
-      return token.charAt(0).toUpperCase() + token.substr(1).toLowerCase();
+      return token.charAt(0).toUpperCase() + token.slice(1).toLowerCase();
     }
 
     // Lower cased words. E.g. "test".

--- a/packages/akita-schematics/src/ng-g/utils/project.ts
+++ b/packages/akita-schematics/src/ng-g/utils/project.ts
@@ -10,8 +10,8 @@ export function getProjectPath(host: Tree, options: { project?: string | undefin
 
   const project = workspace.projects[options.project];
 
-  if (project.root.substr(-1) === '/') {
-    project.root = project.root.substr(0, project.root.length - 1);
+  if (project.root.slice(-1) === '/') {
+    project.root = project.root.slice(0, -1);
   }
 
   if (options.path === undefined) {

--- a/packages/akita-schematics/src/ng-g/utils/string.ts
+++ b/packages/akita-schematics/src/ng-g/utils/string.ts
@@ -106,7 +106,7 @@ export function underscore(str: string): string {
  ```
  */
 export function capitalize(str: string): string {
-  return str.charAt(0).toUpperCase() + str.substr(1);
+  return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
 export function singular(value: string) {

--- a/packages/akita-schematics/src/schematics-core/utility/project.ts
+++ b/packages/akita-schematics/src/schematics-core/utility/project.ts
@@ -19,8 +19,8 @@ export function getProject(host: Tree, options: { project?: string | undefined; 
 export function getProjectPath(host: Tree, options: { project?: string | undefined; path?: string | undefined }) {
   const project = getProject(host, options);
 
-  if (project.root.substr(-1) === '/') {
-    project.root = project.root.substr(0, project.root.length - 1);
+  if (project.root.slice(-1) === '/') {
+    project.root = project.root.slice(0, -1);
   }
 
   if (options.path === undefined) {

--- a/packages/akita-schematics/src/schematics-core/utility/strings.ts
+++ b/packages/akita-schematics/src/schematics-core/utility/strings.ts
@@ -107,7 +107,7 @@ export function underscore(str: string): string {
  ```
  */
 export function capitalize(str: string): string {
-  return str.charAt(0).toUpperCase() + str.substr(1);
+  return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
 /**


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

## What is the new behavior?

No change, except without a deprecated function

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

